### PR TITLE
fix: close the 0.4.0 known-limitations list

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,0 +1,22 @@
+# Git hooks
+
+Version-controlled hooks for this repo. They mirror the CI gates so a push never
+fails on something a local check would have caught.
+
+## One-time setup (per clone)
+
+```sh
+git config core.hooksPath .githooks
+```
+
+That points git at this directory instead of `.git/hooks`. On Windows the hooks
+run through Git's bundled `sh`, so no extra setup is needed.
+
+## Hooks
+
+- **`pre-commit`** — runs `cargo fmt --all --check` and
+  `cargo clippy --workspace --all-targets -- -D warnings` (exactly what
+  `.github/workflows/ci.yml` runs). It skips automatically when a commit touches
+  no `.rs` / `.wgsl` / `Cargo.*` files.
+
+Bypass a hook for a single commit with `git commit --no-verify`.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# zpdf pre-commit hook — run the same gates as CI (rustfmt + clippy) before a
+# commit is created, so a push never fails on formatting or lints.
+#
+# Skips automatically when a commit touches no buildable sources (docs-only,
+# fixtures, etc.). Bypass in a pinch with `git commit --no-verify`.
+set -euo pipefail
+
+# Only gate commits that actually touch Rust / shader / Cargo sources.
+staged=$(git diff --cached --name-only --diff-filter=ACMR)
+if ! printf '%s\n' "$staged" | grep -qE '\.(rs|wgsl)$|(^|/)Cargo\.(toml|lock)$'; then
+    exit 0
+fi
+
+echo "pre-commit › cargo fmt --all --check"
+if ! cargo fmt --all --check; then
+    echo >&2
+    echo "✗ rustfmt: run 'cargo fmt --all', re-stage the files, and commit again." >&2
+    exit 1
+fi
+
+echo "pre-commit › cargo clippy --workspace --all-targets -- -D warnings"
+if ! cargo clippy --workspace --all-targets -- -D warnings; then
+    echo >&2
+    echo "✗ clippy found issues. Fix them, or bypass with 'git commit --no-verify'." >&2
+    exit 1
+fi
+
+echo "pre-commit ✓ fmt + clippy clean"

--- a/crates/zpdf-color/src/icc.rs
+++ b/crates/zpdf-color/src/icc.rs
@@ -15,6 +15,40 @@ use moxcms::{
 };
 use zpdf_core::{Error, ObjectId, Result};
 
+/// PDF colour rendering intent (ISO 32000-1 §8.6.5.8) — the `ri` operator,
+/// ExtGState `/RI`, and image `/Intent`. Defaults to media-relative
+/// colorimetric, the PDF default.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum RenderIntent {
+    Perceptual,
+    #[default]
+    RelativeColorimetric,
+    Saturation,
+    AbsoluteColorimetric,
+}
+
+impl RenderIntent {
+    /// Map a PDF intent name to an intent. Unknown names fall back to the
+    /// media-relative colorimetric default (per the spec's recommendation).
+    pub fn from_pdf_name(name: &str) -> Self {
+        match name {
+            "Perceptual" => Self::Perceptual,
+            "Saturation" => Self::Saturation,
+            "AbsoluteColorimetric" => Self::AbsoluteColorimetric,
+            _ => Self::RelativeColorimetric,
+        }
+    }
+
+    fn to_moxcms(self) -> RenderingIntent {
+        match self {
+            Self::Perceptual => RenderingIntent::Perceptual,
+            Self::RelativeColorimetric => RenderingIntent::RelativeColorimetric,
+            Self::Saturation => RenderingIntent::Saturation,
+            Self::AbsoluteColorimetric => RenderingIntent::AbsoluteColorimetric,
+        }
+    }
+}
+
 /// A compiled ICC-profile → sRGB transform for 1/3/4-component input.
 ///
 /// The underlying executor is `Send + Sync`, so a transform can be shared
@@ -38,7 +72,7 @@ impl IccTransform {
     /// Supported data colour spaces: Gray (1 component), RGB and Lab (3),
     /// CMYK (4). Anything else — including malformed or truncated profiles —
     /// is an error so the caller can keep its `/N`-based fallback.
-    pub fn from_profile_bytes(data: &[u8]) -> Result<Self> {
+    pub fn from_profile_bytes(data: &[u8], intent: RenderIntent) -> Result<Self> {
         let profile = ColorProfile::new_from_slice(data)
             .map_err(|e| Error::StreamDecode(format!("ICC profile parse failed: {e:?}")))?;
         let (layout, ncomp) = match profile.color_space {
@@ -55,11 +89,11 @@ impl IccTransform {
             }
         };
         let srgb = ColorProfile::new_srgb();
-        // TODO(/RenderingIntent): plumb the PDF rendering intent through to
-        // here. For now use media-relative colorimetric, retrying perceptual
-        // for LUT profiles that only carry an A2B0 table (the ICC-mandated
-        // fallback order).
+        // Try the requested PDF rendering intent first, then fall back through
+        // media-relative colorimetric and perceptual — the ICC-mandated order
+        // for LUT profiles that only carry a subset of A2B tables.
         let executor = [
+            intent.to_moxcms(),
             RenderingIntent::RelativeColorimetric,
             RenderingIntent::Perceptual,
         ]
@@ -137,11 +171,12 @@ impl IccTransform {
 }
 
 /// Per-document cache of ICCBased profile streams → compiled transforms,
-/// keyed by the profile stream's object id. Failures are cached as `None`
-/// so a malformed profile is parsed (and warned about) only once.
+/// keyed by the profile stream's object id AND the rendering intent (the same
+/// profile may be requested under different intents on one page). Failures are
+/// cached as `None` so a malformed profile is parsed (and warned about) once.
 #[derive(Debug, Default)]
 pub struct IccCache {
-    transforms: HashMap<ObjectId, Option<Arc<IccTransform>>>,
+    transforms: HashMap<(ObjectId, RenderIntent), Option<Arc<IccTransform>>>,
 }
 
 impl IccCache {
@@ -149,19 +184,20 @@ impl IccCache {
         Self::default()
     }
 
-    /// The cached transform for profile stream `id`, building it from the
-    /// bytes returned by `data` on first use. `data` returning `None`
+    /// The cached transform for profile stream `id` under `intent`, building it
+    /// from the bytes returned by `data` on first use. `data` returning `None`
     /// (unresolvable stream) also caches as a failure.
     pub fn get_or_build(
         &mut self,
         id: ObjectId,
+        intent: RenderIntent,
         data: impl FnOnce() -> Option<Vec<u8>>,
     ) -> Option<Arc<IccTransform>> {
         self.transforms
-            .entry(id)
+            .entry((id, intent))
             .or_insert_with(|| {
                 let bytes = data()?;
-                match IccTransform::from_profile_bytes(&bytes) {
+                match IccTransform::from_profile_bytes(&bytes, intent) {
                     Ok(t) => Some(Arc::new(t)),
                     Err(e) => {
                         tracing::warn!(
@@ -184,9 +220,15 @@ mod tests {
     const GRAY_LINEAR: &[u8] = include_bytes!("testdata/gray_linear.icc");
     const CMYK_LUT: &[u8] = include_bytes!("testdata/cmyk_lut.icc");
 
+    /// The default media-relative colorimetric intent, for tests that don't
+    /// exercise intent selection.
+    fn ri() -> RenderIntent {
+        RenderIntent::default()
+    }
+
     #[test]
     fn srgb_profile_is_identity() {
-        let t = IccTransform::from_profile_bytes(SRGB).unwrap();
+        let t = IccTransform::from_profile_bytes(SRGB, ri()).unwrap();
         assert_eq!(t.components(), 3);
         let mut out = [0u8; 6];
         t.slice_to_rgb(&[10, 128, 240, 0, 255, 64], &mut out)
@@ -198,7 +240,7 @@ mod tests {
 
     #[test]
     fn srgb_float_color_roundtrips() {
-        let t = IccTransform::from_profile_bytes(SRGB).unwrap();
+        let t = IccTransform::from_profile_bytes(SRGB, ri()).unwrap();
         let (r, g, b) = t.color_to_rgb(&[1.0, 0.0, 0.0]);
         assert!(r > 0.98 && g < 0.02 && b < 0.02, "got {r} {g} {b}");
     }
@@ -207,7 +249,7 @@ mod tests {
     fn gray_gamma22_tone_curve_applies() {
         // A gamma-2.2 gray curve is close to (but not exactly) sRGB's
         // transfer: 128 → encode(0.502^2.2) ≈ 129.
-        let t = IccTransform::from_profile_bytes(GRAY_GAMMA22).unwrap();
+        let t = IccTransform::from_profile_bytes(GRAY_GAMMA22, ri()).unwrap();
         assert_eq!(t.components(), 1);
         let mut out = [0u8; 9];
         t.slice_to_rgb(&[0, 128, 255], &mut out).unwrap();
@@ -220,7 +262,7 @@ mod tests {
     fn gray_linear_brightens_midtones() {
         // Linear gray re-encoded with the sRGB curve: 128 → ≈188, a visible
         // departure from the old pass-through (which would keep 128).
-        let t = IccTransform::from_profile_bytes(GRAY_LINEAR).unwrap();
+        let t = IccTransform::from_profile_bytes(GRAY_LINEAR, ri()).unwrap();
         let mut out = [0u8; 3];
         t.slice_to_rgb(&[128], &mut out).unwrap();
         assert!((out[0] as i16 - 188).abs() <= 2, "midtone: {out:?}");
@@ -228,7 +270,7 @@ mod tests {
 
     #[test]
     fn cmyk_lut_profile_converts_through_lut() {
-        let t = IccTransform::from_profile_bytes(CMYK_LUT).unwrap();
+        let t = IccTransform::from_profile_bytes(CMYK_LUT, ri()).unwrap();
         assert_eq!(t.components(), 4);
         // white, black (K only), cyan
         let src = [0u8, 0, 0, 0, 0, 0, 0, 255, 255, 0, 0, 0];
@@ -247,7 +289,7 @@ mod tests {
         // A wide-gamut profile must visibly move saturated colours; built
         // with moxcms here so no large fixture is needed.
         let bytes = moxcms::ColorProfile::new_adobe_rgb().encode().unwrap();
-        let t = IccTransform::from_profile_bytes(&bytes).unwrap();
+        let t = IccTransform::from_profile_bytes(&bytes, ri()).unwrap();
         let mut out = [0u8; 3];
         t.slice_to_rgb(&[60, 200, 60], &mut out).unwrap();
         assert!(
@@ -257,10 +299,65 @@ mod tests {
     }
 
     #[test]
+    fn render_intent_name_mapping() {
+        use RenderIntent::*;
+        assert_eq!(RenderIntent::from_pdf_name("Perceptual"), Perceptual);
+        assert_eq!(
+            RenderIntent::from_pdf_name("RelativeColorimetric"),
+            RelativeColorimetric
+        );
+        assert_eq!(RenderIntent::from_pdf_name("Saturation"), Saturation);
+        assert_eq!(
+            RenderIntent::from_pdf_name("AbsoluteColorimetric"),
+            AbsoluteColorimetric
+        );
+        // Unknown / unspecified → media-relative colorimetric default.
+        assert_eq!(RenderIntent::from_pdf_name("Bogus"), RelativeColorimetric);
+        assert_eq!(RenderIntent::default(), RelativeColorimetric);
+    }
+
+    #[test]
+    fn every_intent_compiles_a_working_transform() {
+        use RenderIntent::*;
+        for intent in [
+            Perceptual,
+            RelativeColorimetric,
+            Saturation,
+            AbsoluteColorimetric,
+        ] {
+            let t = IccTransform::from_profile_bytes(SRGB, intent)
+                .unwrap_or_else(|e| panic!("intent {intent:?} failed: {e}"));
+            let mut out = [0u8; 3];
+            t.slice_to_rgb(&[200, 50, 50], &mut out).unwrap();
+            // sRGB→sRGB stays near identity for every intent (no gamut clip).
+            assert!((out[0] as i16 - 200).abs() <= 4, "{intent:?}: {out:?}");
+        }
+    }
+
+    #[test]
+    fn cache_separates_transforms_by_intent() {
+        let mut cache = IccCache::new();
+        let id = ObjectId(11, 0);
+        let mut calls = 0;
+        let _a = cache.get_or_build(id, RenderIntent::Perceptual, || {
+            calls += 1;
+            Some(SRGB.to_vec())
+        });
+        // A different intent must NOT reuse the perceptual entry.
+        let _b = cache.get_or_build(id, RenderIntent::AbsoluteColorimetric, || {
+            calls += 1;
+            Some(SRGB.to_vec())
+        });
+        assert_eq!(calls, 2, "intents must be cached separately");
+        // Same (id, intent) reuses.
+        let _c = cache.get_or_build(id, RenderIntent::Perceptual, || unreachable!());
+    }
+
+    #[test]
     fn malformed_profile_is_rejected() {
-        assert!(IccTransform::from_profile_bytes(&[0u8; 256]).is_err());
-        assert!(IccTransform::from_profile_bytes(&SRGB[..100]).is_err());
-        assert!(IccTransform::from_profile_bytes(b"").is_err());
+        assert!(IccTransform::from_profile_bytes(&[0u8; 256], ri()).is_err());
+        assert!(IccTransform::from_profile_bytes(&SRGB[..100], ri()).is_err());
+        assert!(IccTransform::from_profile_bytes(b"", ri()).is_err());
     }
 
     #[test]
@@ -269,7 +366,7 @@ mod tests {
         let id = ObjectId(7, 0);
         let mut calls = 0;
         for _ in 0..2 {
-            let t = cache.get_or_build(id, || {
+            let t = cache.get_or_build(id, ri(), || {
                 calls += 1;
                 Some(vec![0u8; 64])
             });
@@ -282,14 +379,16 @@ mod tests {
     fn cache_shares_one_transform_per_id() {
         let mut cache = IccCache::new();
         let id = ObjectId(3, 0);
-        let a = cache.get_or_build(id, || Some(SRGB.to_vec())).unwrap();
-        let b = cache.get_or_build(id, || unreachable!()).unwrap();
+        let a = cache
+            .get_or_build(id, ri(), || Some(SRGB.to_vec()))
+            .unwrap();
+        let b = cache.get_or_build(id, ri(), || unreachable!()).unwrap();
         assert!(Arc::ptr_eq(&a, &b));
     }
 
     #[test]
     fn palette_bakes_through_transform() {
-        let t = IccTransform::from_profile_bytes(GRAY_LINEAR).unwrap();
+        let t = IccTransform::from_profile_bytes(GRAY_LINEAR, ri()).unwrap();
         let rgb = t.palette_to_rgb(&[0, 128, 255]);
         assert_eq!(rgb.len(), 9);
         assert_eq!(&rgb[0..3], &[0, 0, 0]);

--- a/crates/zpdf-color/src/lib.rs
+++ b/crates/zpdf-color/src/lib.rs
@@ -4,7 +4,7 @@ pub mod function;
 pub mod icc;
 
 pub use function::PdfFunction;
-pub use icc::{IccCache, IccTransform};
+pub use icc::{IccCache, IccTransform, RenderIntent};
 
 #[derive(Debug, Clone)]
 pub enum ColorSpace {

--- a/crates/zpdf-content/src/interpreter.rs
+++ b/crates/zpdf-content/src/interpreter.rs
@@ -242,6 +242,9 @@ struct GraphicsState {
     blend_mode: BlendMode,
     /// ExtGState /SMask currently in effect (None = no soft mask).
     soft_mask: Option<SoftMask>,
+    /// Colour rendering intent (`ri` operator / ExtGState /RI). Applied when
+    /// compiling ICCBased profiles into transforms.
+    rendering_intent: zpdf_color::RenderIntent,
 }
 
 impl Default for GraphicsState {
@@ -272,6 +275,7 @@ impl Default for GraphicsState {
             stroke_pattern: None,
             blend_mode: BlendMode::Normal,
             soft_mask: None,
+            rendering_intent: zpdf_color::RenderIntent::RelativeColorimetric,
         }
     }
 }
@@ -611,8 +615,13 @@ impl<'a> ContentInterpreter<'a> {
                     }
                 }
             }
-            "i" | "ri" => {
-                // flatness, rendering intent - consume operands
+            "ri" => {
+                // Rendering intent: a name operand selecting the colour intent.
+                let name = self.pop_name();
+                self.current.rendering_intent = zpdf_color::RenderIntent::from_pdf_name(&name);
+            }
+            "i" => {
+                // Flatness tolerance — does not affect raster output.
             }
             "gs" => {
                 let name = self.pop_name();
@@ -1142,15 +1151,16 @@ impl<'a> ContentInterpreter<'a> {
     ) -> Option<std::sync::Arc<zpdf_color::IccTransform>> {
         self.icc_cache.as_ref()?;
         let file = self.file;
+        let intent = self.current.rendering_intent;
         let transform = match obj? {
             PdfObject::Ref(r) => {
                 let file = file?;
                 let cache = self.icc_cache.as_deref_mut()?;
-                cache.get_or_build(*r, || file.resolve_stream_data(*r).ok())
+                cache.get_or_build(*r, intent, || file.resolve_stream_data(*r).ok())
             }
             // Inline profile streams (synthetic content; the spec requires an
             // indirect stream) have no object id to cache under.
-            PdfObject::Stream(s) => build_inline_icc_transform(s),
+            PdfObject::Stream(s) => build_inline_icc_transform(s, intent),
             _ => None,
         }?;
         if transform.components() != n.max(1) as usize {
@@ -1805,7 +1815,11 @@ impl<'a> ContentInterpreter<'a> {
         if self.current.blend_mode != BlendMode::Normal || self.current.soft_mask.is_some() {
             self.display_list.push(RenderCommand::PushBlendGroup {
                 blend_mode: self.current.blend_mode,
-                isolated: false,
+                // A single object carrying a blend mode / soft mask is equivalent
+                // to an isolated group of one element composited with that mode —
+                // it must NOT pull in the backdrop (which would change a
+                // semi-transparent blended fill).
+                isolated: true,
                 knockout: false,
                 bounds: self.display_list.page_rect,
                 alpha: 1.0,
@@ -1874,6 +1888,10 @@ impl<'a> ContentInterpreter<'a> {
         }
         if let Ok(m) = dict.get_f64("ML") {
             self.current.miter_limit = m as f32;
+        }
+        // /RI: rendering intent name.
+        if let Ok(ri) = dict.get_name("RI") {
+            self.current.rendering_intent = zpdf_color::RenderIntent::from_pdf_name(ri);
         }
         // /BM: a name or an array of names (use the first supported one).
         let bm_name = match dict.get("BM") {
@@ -2139,11 +2157,18 @@ impl<'a> ContentInterpreter<'a> {
         // Image metadata keys may be indirect references; resolve them so e.g.
         // an indirect /Decode does not silently invert an /ImageMask stencil.
         let image_dict = resolve_image_metadata(file, &stream.dict);
+        // An image's /Intent overrides the graphics-state rendering intent.
+        let intent = image_dict
+            .get_name("Intent")
+            .ok()
+            .map(zpdf_color::RenderIntent::from_pdf_name)
+            .unwrap_or(self.current.rendering_intent);
         let colorspace = resolve_image_colorspace(
             Some(file),
             self.icc_cache.as_deref_mut(),
             image_dict.get("ColorSpace"),
             0,
+            intent,
         );
         let mut image = match zpdf_image::decode_image_xobject_resolved(
             &decoded_data,
@@ -2202,11 +2227,17 @@ impl<'a> ContentInterpreter<'a> {
                 }
             }
         }
+        let intent = norm
+            .get_name("Intent")
+            .ok()
+            .map(zpdf_color::RenderIntent::from_pdf_name)
+            .unwrap_or(self.current.rendering_intent);
         let colorspace = resolve_image_colorspace(
             self.file,
             self.icc_cache.as_deref_mut(),
             norm.get("ColorSpace"),
             0,
+            intent,
         );
         match zpdf_image::decode_image_xobject_resolved(
             &decoded,
@@ -2590,14 +2621,7 @@ impl<'a> ContentInterpreter<'a> {
             return;
         }
         let page_path = self.transform_path_to_page_space(&path);
-        // Shading-pattern strokes use the precomputed average color.
-        let cmd = RenderCommand::StrokePath {
-            path: page_path,
-            style: self.stroke_style(),
-            paint: Paint::Solid(self.current.stroke_color),
-            alpha: self.current.stroke_alpha,
-        };
-        self.emit_painted(cmd);
+        self.emit_stroke(page_path);
     }
 
     fn paint_fill(&mut self, rule: FillRule) {
@@ -2616,37 +2640,87 @@ impl<'a> ContentInterpreter<'a> {
         }
         let page_path = self.transform_path_to_page_space(&path);
         self.fill_page_path(page_path.clone(), rule);
+        self.emit_stroke(page_path);
+    }
+
+    /// Stroke a page-space path. A stroke pattern (tiling or shading) is clipped
+    /// to the stroke outline via `PushClipStroke`; everything else is a solid
+    /// stroke (shading patterns fall back to the precomputed average colour when
+    /// the region is degenerate).
+    fn emit_stroke(&mut self, page_path: Path) {
+        let style = self.stroke_style();
+        if let Some(pat) = self.current.stroke_pattern.clone() {
+            // The stroke region is the centerline extent grown by the stroke
+            // width. Unlike `path_bounds`, a flat path (a horizontal/vertical
+            // line) is fine here — growing makes the region two-dimensional.
+            if let Some(bounds) = Self::stroke_region_bounds(&page_path, self.current.line_width) {
+                self.display_list.push(RenderCommand::PushClipStroke {
+                    path: page_path.clone(),
+                    style: style.clone(),
+                });
+                let painted = self.paint_pattern_in_region(&pat, bounds);
+                self.display_list.push(RenderCommand::PopClip);
+                if painted {
+                    return;
+                }
+                // Tiling failed to replicate: fall through to a solid stroke
+                // (the clip pair above is balanced and painted nothing).
+            }
+        }
         let cmd = RenderCommand::StrokePath {
             path: page_path,
-            style: self.stroke_style(),
+            style,
             paint: Paint::Solid(self.current.stroke_color),
             alpha: self.current.stroke_alpha,
         };
         self.emit_painted(cmd);
     }
 
-    /// Fill an already page-space path with the active fill paint — a shading
-    /// pattern renders as a gradient image clipped to the path; everything
-    /// else is a solid fill.
-    fn fill_page_path(&mut self, page_path: Path, rule: FillRule) {
-        if let Some(PatternPaint::Shading(def)) = self.current.fill_pattern.clone() {
-            if let Some(bounds) = Self::path_bounds(&page_path) {
-                self.display_list.push(RenderCommand::PushClip {
-                    path: page_path,
-                    rule,
-                });
-                self.emit_shading_image(&def, bounds);
-                self.display_list.push(RenderCommand::PopClip);
-                return;
+    /// Page-space bounding box of a stroke: the path's point extent grown by
+    /// the stroke width on every side (so even a degenerate flat path yields a
+    /// 2-D region for the pattern paint to cover).
+    fn stroke_region_bounds(path: &Path, line_width: f32) -> Option<Rect> {
+        let (mut x0, mut y0, mut x1, mut y1) = (
+            f64::INFINITY,
+            f64::INFINITY,
+            f64::NEG_INFINITY,
+            f64::NEG_INFINITY,
+        );
+        let mut acc = |p: &Point| {
+            x0 = x0.min(p.x);
+            y0 = y0.min(p.y);
+            x1 = x1.max(p.x);
+            y1 = y1.max(p.y);
+        };
+        for elem in &path.elements {
+            match elem {
+                PathElement::MoveTo(p) | PathElement::LineTo(p) => acc(p),
+                PathElement::CurveTo(c1, c2, p) => {
+                    acc(c1);
+                    acc(c2);
+                    acc(p);
+                }
+                PathElement::Close => {}
             }
         }
-        if let Some(PatternPaint::Tiling(def)) = self.current.fill_pattern.clone() {
+        if !(x0.is_finite() && y0.is_finite() && x1.is_finite() && y1.is_finite()) {
+            return None;
+        }
+        let grow = (line_width.max(1.0) as f64).max(0.5);
+        Some(Rect::new(x0 - grow, y0 - grow, x1 + grow, y1 + grow))
+    }
+
+    /// Fill an already page-space path with the active fill paint — a pattern
+    /// (tiling or shading) is clipped to the path; everything else is a solid
+    /// fill.
+    fn fill_page_path(&mut self, page_path: Path, rule: FillRule) {
+        if let Some(pat) = self.current.fill_pattern.clone() {
             if let Some(bounds) = Self::path_bounds(&page_path) {
                 self.display_list.push(RenderCommand::PushClip {
                     path: page_path.clone(),
                     rule,
                 });
-                let painted = self.paint_tiling_pattern(&def, bounds);
+                let painted = self.paint_pattern_in_region(&pat, bounds);
                 self.display_list.push(RenderCommand::PopClip);
                 if painted {
                     return;
@@ -2662,6 +2736,20 @@ impl<'a> ContentInterpreter<'a> {
             alpha: self.current.fill_alpha,
         };
         self.emit_painted(cmd);
+    }
+
+    /// Paint a pattern (tiling or shading) across `bounds`. The caller must
+    /// already have installed the clip region (a path/stroke/glyph clip).
+    /// Returns false when a tiling pattern could not be replicated, so the
+    /// caller can fall back to a solid approximation.
+    fn paint_pattern_in_region(&mut self, pattern: &PatternPaint, bounds: Rect) -> bool {
+        match pattern {
+            PatternPaint::Shading(def) => {
+                self.emit_shading_image(def, bounds);
+                true
+            }
+            PatternPaint::Tiling(def) => self.paint_tiling_pattern(def, bounds),
+        }
     }
 
     /// Replicate a tiling-pattern cell across the page-space `bounds` of a
@@ -2883,6 +2971,30 @@ impl<'a> ContentInterpreter<'a> {
         true
     }
 
+    /// Emit a solid-colour glyph run (the non-pattern path, and the fallback
+    /// when a tiling text pattern cannot be replicated).
+    fn emit_solid_glyph_run(
+        &mut self,
+        font_id: FontId,
+        font_size: f32,
+        glyphs: Vec<PositionedGlyph>,
+        transform: Matrix,
+    ) {
+        let paint_color = match self.current.render_mode {
+            1 | 5 => self.current.stroke_color,
+            _ => self.current.fill_color,
+        };
+        let cmd = RenderCommand::DrawGlyphRun(GlyphRun {
+            font_id,
+            font_size,
+            glyphs,
+            paint: Paint::Solid(paint_color),
+            alpha: self.current.fill_alpha,
+            transform,
+        });
+        self.emit_painted(cmd);
+    }
+
     fn show_text(&mut self, bytes: &[u8]) {
         let tm = self.text_matrix;
         let ctm = self.current.ctm;
@@ -2941,35 +3053,46 @@ impl<'a> ContentInterpreter<'a> {
                 };
                 i += len.max(1);
 
-                // Resolve the glyph id and its 1/1000-unit advance.
-                let (glyph_id, adv_units) = if let Some((_, font)) = font_and_id {
+                // Resolve the glyph id, its 1/1000-unit advance, and (for CID
+                // fonts in vertical mode) the per-CID /W2 vertical metric.
+                let (glyph_id, adv_units, v_metric) = if let Some((_, font)) = font_and_id {
                     if codes_are_unicode {
                         match font.unicode_glyph(code) {
-                            Some((gid, adv)) => (gid, adv),
-                            None => (0, 500.0),
+                            Some((gid, adv)) => (gid, adv, None),
+                            None => (0, 500.0, None),
                         }
                     } else {
                         let cid = cmap
                             .map(|c| c.code_to_cid(code, len as u8))
                             .unwrap_or(code)
                             .min(u16::MAX as u32) as u16;
-                        (cid, font.glyph_advance(cid))
+                        let v_metric = if vertical {
+                            font.cid_v_metric(cid)
+                        } else {
+                            None
+                        };
+                        (cid, font.glyph_advance(cid), v_metric)
                     }
                 } else {
-                    (code.min(u16::MAX as u32) as u16, 500.0)
+                    (code.min(u16::MAX as u32) as u16, 500.0, None)
                 };
 
                 if vertical {
                     // Vertical writing (9.7.4.3): the glyph's horizontal origin
-                    // sits at pen − v, v = (w0/2, vy); the pen advances by
-                    // ty = w1·Tfs + Tc (+ Tw for 1-byte code 32) per 9.4.4 —
-                    // no Th factor in vertical mode.
-                    let w0 = adv_units as f32 * scale_factor;
-                    let vy = dw2.0 as f32 * scale_factor;
-                    let advance = dw2.1 as f32 * scale_factor;
+                    // sits at pen − v; the pen advances by ty = w1y·Tfs + Tc
+                    // (+ Tw for 1-byte code 32) per 9.4.4 — no Th factor in
+                    // vertical mode. Per-CID /W2 overrides /DW2 when present;
+                    // the /DW2 default position vector is (w0/2, vy).
+                    let (w1y, vx, vy) = match v_metric {
+                        Some((w1y, vx, vy)) => (w1y, vx, vy),
+                        None => (dw2.1, adv_units / 2.0, dw2.0),
+                    };
+                    let vx = vx as f32 * scale_factor;
+                    let vy = vy as f32 * scale_factor;
+                    let advance = w1y as f32 * scale_factor;
                     glyphs.push(PositionedGlyph {
                         glyph_id,
-                        x: -w0 / 2.0,
+                        x: -vx,
                         y: x_offset - vy,
                         advance,
                     });
@@ -3064,19 +3187,32 @@ impl<'a> ContentInterpreter<'a> {
         let invisible = matches!(self.current.render_mode, 3 | 7);
         if let Some(font_id) = self.current_font_id {
             if !glyphs.is_empty() && !invisible {
-                let paint_color = match self.current.render_mode {
-                    1 | 5 => self.current.stroke_color,
-                    _ => self.current.fill_color,
+                // A Pattern colour space on the active paint (fill for modes
+                // 0/2/4/6, stroke for 1/5) clips the pattern to the glyph
+                // outlines instead of painting a solid run.
+                let text_pattern = match self.current.render_mode {
+                    1 | 5 => self.current.stroke_pattern.clone(),
+                    _ => self.current.fill_pattern.clone(),
                 };
-                let cmd = RenderCommand::DrawGlyphRun(GlyphRun {
-                    font_id,
-                    font_size,
-                    glyphs,
-                    paint: Paint::Solid(paint_color),
-                    alpha: self.current.fill_alpha,
-                    transform: combined,
+                let glyph_clip = text_pattern.as_ref().and_then(|_| {
+                    font_and_id.and_then(|(_, font)| {
+                        build_glyph_clip_path(&glyphs, &combined, font, font_size)
+                    })
                 });
-                self.emit_painted(cmd);
+                match (text_pattern, glyph_clip) {
+                    (Some(pat), Some((clip_path, bounds))) => {
+                        self.display_list.push(RenderCommand::PushClip {
+                            path: clip_path,
+                            rule: FillRule::NonZero,
+                        });
+                        let painted = self.paint_pattern_in_region(&pat, bounds);
+                        self.display_list.push(RenderCommand::PopClip);
+                        if !painted {
+                            self.emit_solid_glyph_run(font_id, font_size, glyphs, combined);
+                        }
+                    }
+                    _ => self.emit_solid_glyph_run(font_id, font_size, glyphs, combined),
+                }
             }
         }
 
@@ -3171,13 +3307,110 @@ fn resolve_image_metadata(file: &PdfFile, dict: &zpdf_core::PdfDict) -> zpdf_cor
     out
 }
 
+/// Build a combined glyph-outline clip path (in PAGE space) for a positioned
+/// glyph run, plus its bounding box. Used to clip a pattern/shading paint to
+/// text. Returns `None` for fonts with no usable outlines (bitmap/Type3) or an
+/// all-blank run. Quadratic segments are promoted to cubics for the display
+/// list `Path` (which carries cubics only).
+fn build_glyph_clip_path(
+    glyphs: &[PositionedGlyph],
+    tm: &Matrix,
+    font: &zpdf_font::LoadedFont,
+    font_size: f32,
+) -> Option<(Path, Rect)> {
+    if !font.has_font_data() || font.is_type3() {
+        return None;
+    }
+    let upem = font.units_per_em as f32;
+    if upem <= 0.0 {
+        return None;
+    }
+
+    // Glyph-space point (font units, + the glyph's text-space offset) → page.
+    let to_page = |gx: f64, gy: f64, ox: f32, oy: f32| -> Point {
+        let tx = (gx as f32 / upem * font_size + ox) as f64;
+        let ty = (gy as f32 / upem * font_size + oy) as f64;
+        Point::new(tm.a * tx + tm.c * ty + tm.e, tm.b * tx + tm.d * ty + tm.f)
+    };
+
+    let mut out = Path::new();
+    let mut bb = (
+        f64::INFINITY,
+        f64::INFINITY,
+        f64::NEG_INFINITY,
+        f64::NEG_INFINITY,
+    );
+    let track = |p: Point, bb: &mut (f64, f64, f64, f64)| {
+        bb.0 = bb.0.min(p.x);
+        bb.1 = bb.1.min(p.y);
+        bb.2 = bb.2.max(p.x);
+        bb.3 = bb.3.max(p.y);
+    };
+    let mut any = false;
+
+    for glyph in glyphs {
+        let outline = match font.glyph_outline(glyph.glyph_id) {
+            Some(o) => o,
+            None => continue,
+        };
+        let (ox, oy) = (glyph.x, glyph.y);
+        let mut cur = Point::new(0.0, 0.0);
+        for cmd in &outline.commands {
+            match *cmd {
+                zpdf_font::OutlineCommand::MoveTo(x, y) => {
+                    let p = to_page(x, y, ox, oy);
+                    out.move_to(p);
+                    track(p, &mut bb);
+                    cur = p;
+                    any = true;
+                }
+                zpdf_font::OutlineCommand::LineTo(x, y) => {
+                    let p = to_page(x, y, ox, oy);
+                    out.line_to(p);
+                    track(p, &mut bb);
+                    cur = p;
+                }
+                zpdf_font::OutlineCommand::QuadTo(cx, cy, x, y) => {
+                    let c = to_page(cx, cy, ox, oy);
+                    let e = to_page(x, y, ox, oy);
+                    // Quadratic → cubic: control points at 2/3 toward the quad ctrl.
+                    let c1 = Point::new(
+                        cur.x + 2.0 / 3.0 * (c.x - cur.x),
+                        cur.y + 2.0 / 3.0 * (c.y - cur.y),
+                    );
+                    let c2 =
+                        Point::new(e.x + 2.0 / 3.0 * (c.x - e.x), e.y + 2.0 / 3.0 * (c.y - e.y));
+                    out.curve_to(c1, c2, e);
+                    track(e, &mut bb);
+                    cur = e;
+                }
+                zpdf_font::OutlineCommand::CurveTo(x1, y1, x2, y2, x, y) => {
+                    let c1 = to_page(x1, y1, ox, oy);
+                    let c2 = to_page(x2, y2, ox, oy);
+                    let e = to_page(x, y, ox, oy);
+                    out.curve_to(c1, c2, e);
+                    track(e, &mut bb);
+                    cur = e;
+                }
+                zpdf_font::OutlineCommand::Close => out.close(),
+            }
+        }
+    }
+
+    if !(any && bb.0.is_finite() && bb.2 > bb.0 && bb.3 > bb.1) {
+        return None;
+    }
+    Some((out, Rect::new(bb.0, bb.1, bb.2, bb.3)))
+}
+
 /// Build an ICC transform from an inline (synthetic) profile stream,
 /// bypassing the cache — inline streams have no object id to key on.
 fn build_inline_icc_transform(
     s: &zpdf_core::PdfStream,
+    intent: zpdf_color::RenderIntent,
 ) -> Option<std::sync::Arc<zpdf_color::IccTransform>> {
     let data = zpdf_parser::filters::decode_stream(&s.data, &s.dict).ok()?;
-    match zpdf_color::IccTransform::from_profile_bytes(&data) {
+    match zpdf_color::IccTransform::from_profile_bytes(&data, intent) {
         Ok(t) => Some(std::sync::Arc::new(t)),
         Err(e) => {
             tracing::warn!("inline ICC profile rejected: {e}; using /N fallback");
@@ -3197,6 +3430,7 @@ fn resolve_image_colorspace(
     icc: Option<&mut zpdf_color::IccCache>,
     cs: Option<&PdfObject>,
     depth: u8,
+    intent: zpdf_color::RenderIntent,
 ) -> Option<zpdf_image::ResolvedColorSpace> {
     use zpdf_image::ResolvedColorSpace as Rcs;
     if depth > 4 {
@@ -3233,9 +3467,9 @@ fn resolve_image_colorspace(
                     if let Some(cache) = icc {
                         let transform = match (stream_ref, file) {
                             (Some(id), Some(f)) => {
-                                cache.get_or_build(id, || f.resolve_stream_data(id).ok())
+                                cache.get_or_build(id, intent, || f.resolve_stream_data(id).ok())
                             }
-                            (None, _) => build_inline_icc_transform(stream),
+                            (None, _) => build_inline_icc_transform(stream, intent),
                             _ => None,
                         };
                         if let Some(t) = transform {
@@ -3262,7 +3496,7 @@ fn resolve_image_colorspace(
                     }
                 }
                 "Indexed" | "I" => {
-                    let base = resolve_image_colorspace(file, icc, arr.get(1), depth + 1)?;
+                    let base = resolve_image_colorspace(file, icc, arr.get(1), depth + 1, intent)?;
                     let hival = arr.get(2)?.as_f64().ok()?;
                     if !(0.0..=255.0).contains(&hival) {
                         return None;
@@ -3435,6 +3669,54 @@ mod tests {
         assert_eq!(dl.commands.len(), 2);
     }
 
+    /// `build_glyph_clip_path` produces a real outline clip + bbox from a
+    /// loaded font (the geometry behind pattern-filled text). Uses the
+    /// committed Quartz CFF fixture; skips gracefully if it is absent.
+    #[test]
+    fn glyph_clip_path_from_real_font() {
+        let fixture = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../zpdf/tests/fixtures/quartz_cff_subset.pdf"
+        );
+        let Ok(data) = std::fs::read(fixture) else {
+            return; // fixture not present in this checkout
+        };
+        let doc = zpdf_document::PdfDocument::open(data).expect("open fixture");
+        // CMBX12 is object 4; GID 26 = 'U', GID 42 = 'n' both have outlines.
+        let font =
+            zpdf_document::font_loader::load_single_font(doc.file(), zpdf_core::ObjectId(4, 0))
+                .expect("load CMBX12");
+        let glyphs = vec![
+            PositionedGlyph {
+                glyph_id: 26,
+                x: 0.0,
+                y: 0.0,
+                advance: 0.0,
+            },
+            PositionedGlyph {
+                glyph_id: 42,
+                x: 50.0,
+                y: 0.0,
+                advance: 0.0,
+            },
+        ];
+        let (path, bounds) = build_glyph_clip_path(&glyphs, &Matrix::identity(), &font, 100.0)
+            .expect("glyph clip path");
+        assert!(
+            !path.elements.is_empty(),
+            "clip path should carry outline elements"
+        );
+        assert!(
+            bounds.x1 > bounds.x0 && bounds.y1 > bounds.y0,
+            "non-empty bbox: {bounds:?}"
+        );
+        // Two ~100pt glyphs starting at x=0 and x=50 stay within a sane span.
+        assert!(
+            bounds.x0 >= -5.0 && bounds.x1 < 250.0,
+            "bbox span: {bounds:?}"
+        );
+    }
+
     /// A FontCache with a single placeholder font registered as `F1`, so that a
     /// `/F1 Tf` selects an active font and text operators emit glyph runs.
     fn cache_with_f1() -> FontCache {
@@ -3502,16 +3784,37 @@ mod tests {
         use zpdf_image::ResolvedColorSpace as Rcs;
         let cs = PdfObject::Name(PdfName::new("DeviceCMYK"));
         assert_eq!(
-            resolve_image_colorspace(None, None, Some(&cs), 0),
+            resolve_image_colorspace(
+                None,
+                None,
+                Some(&cs),
+                0,
+                zpdf_color::RenderIntent::default()
+            ),
             Some(Rcs::Cmyk)
         );
         let cs = PdfObject::Name(PdfName::new("CalGray"));
         assert_eq!(
-            resolve_image_colorspace(None, None, Some(&cs), 0),
+            resolve_image_colorspace(
+                None,
+                None,
+                Some(&cs),
+                0,
+                zpdf_color::RenderIntent::default()
+            ),
             Some(Rcs::Gray)
         );
         let cs = PdfObject::Name(PdfName::new("Pattern"));
-        assert_eq!(resolve_image_colorspace(None, None, Some(&cs), 0), None);
+        assert_eq!(
+            resolve_image_colorspace(
+                None,
+                None,
+                Some(&cs),
+                0,
+                zpdf_color::RenderIntent::default()
+            ),
+            None
+        );
     }
 
     #[test]
@@ -3527,7 +3830,13 @@ mod tests {
             PdfObject::Stream(PdfStream::new(profile_dict, vec![])),
         ]);
         assert_eq!(
-            resolve_image_colorspace(None, None, Some(&cs), 0),
+            resolve_image_colorspace(
+                None,
+                None,
+                Some(&cs),
+                0,
+                zpdf_color::RenderIntent::default()
+            ),
             Some(Rcs::Cmyk)
         );
     }
@@ -3542,7 +3851,13 @@ mod tests {
             PdfObject::Integer(1),
             PdfObject::String(PdfString::new(vec![255, 0, 0, 0, 0, 255])),
         ]);
-        match resolve_image_colorspace(None, None, Some(&cs), 0) {
+        match resolve_image_colorspace(
+            None,
+            None,
+            Some(&cs),
+            0,
+            zpdf_color::RenderIntent::default(),
+        ) {
             Some(Rcs::Indexed {
                 base,
                 hival,
@@ -3567,7 +3882,16 @@ mod tests {
             PdfObject::Integer(1),
             PdfObject::Ref(ObjectId(7, 0)),
         ]);
-        assert_eq!(resolve_image_colorspace(None, None, Some(&cs), 0), None);
+        assert_eq!(
+            resolve_image_colorspace(
+                None,
+                None,
+                Some(&cs),
+                0,
+                zpdf_color::RenderIntent::default()
+            ),
+            None
+        );
     }
 
     // ---- ICCBased with real profile transforms ----
@@ -3634,14 +3958,26 @@ mod tests {
         use zpdf_image::ResolvedColorSpace as Rcs;
         let mut cache = zpdf_color::IccCache::new();
         let cs = iccbased_cs(SRGB_ICC, 3);
-        match resolve_image_colorspace(None, Some(&mut cache), Some(&cs), 0) {
+        match resolve_image_colorspace(
+            None,
+            Some(&mut cache),
+            Some(&cs),
+            0,
+            zpdf_color::RenderIntent::default(),
+        ) {
             Some(Rcs::Icc { ncomp: 3, .. }) => {}
             other => panic!("expected Icc, got {other:?}"),
         }
         // Garbage profile: back to the /N mapping.
         let cs = iccbased_cs(&[0u8; 64], 4);
         assert_eq!(
-            resolve_image_colorspace(None, Some(&mut cache), Some(&cs), 0),
+            resolve_image_colorspace(
+                None,
+                Some(&mut cache),
+                Some(&cs),
+                0,
+                zpdf_color::RenderIntent::default()
+            ),
             Some(Rcs::Cmyk)
         );
     }
@@ -3659,7 +3995,13 @@ mod tests {
             PdfObject::Integer(1),
             PdfObject::String(PdfString::new(vec![255, 0, 0, 0, 0, 255])),
         ]);
-        match resolve_image_colorspace(None, Some(&mut cache), Some(&cs), 0) {
+        match resolve_image_colorspace(
+            None,
+            Some(&mut cache),
+            Some(&cs),
+            0,
+            zpdf_color::RenderIntent::default(),
+        ) {
             Some(Rcs::Indexed { base, lookup, .. }) => {
                 assert_eq!(*base, Rcs::Rgb);
                 assert_eq!(lookup.len(), 6);

--- a/crates/zpdf-display-list/src/lib.rs
+++ b/crates/zpdf-display-list/src/lib.rs
@@ -39,6 +39,13 @@ pub enum RenderCommand {
         path: Path,
         rule: FillRule,
     },
+    /// Intersect the clip with a *stroked* path's outline (not its fill).
+    /// Used to clip a pattern/shading paint to a stroke, since stroke geometry
+    /// is the backend's job. Released by the matching [`RenderCommand::PopClip`].
+    PushClipStroke {
+        path: Path,
+        style: StrokeStyle,
+    },
     PopClip,
     PushBlendGroup {
         blend_mode: BlendMode,

--- a/crates/zpdf-document/src/font_loader.rs
+++ b/crates/zpdf-document/src/font_loader.rs
@@ -301,7 +301,8 @@ fn load_type0_font(
     let desc_obj = file.resolve(desc_ref)?;
     let desc_dict = desc_obj.as_dict()?;
 
-    let cid_widths = parse_cid_widths(file, desc_dict);
+    let mut cid_widths = parse_cid_widths(file, desc_dict);
+    parse_cid_w2(file, desc_dict, &mut cid_widths);
     let cmap = parse_type0_encoding(file, dict);
     let dw2 = parse_dw2(file, desc_dict);
 
@@ -672,6 +673,73 @@ fn parse_cid_widths(file: &PdfFile, dict: &zpdf_core::PdfDict) -> CidWidths {
     widths
 }
 
+/// Parse the CID /W2 array (PDF 9.7.4.3) into per-CID vertical metrics.
+/// Two element forms, mirroring /W but with THREE numbers per glyph:
+///   `c [ w1y_1 vx_1 vy_1  w1y_2 vx_2 vy_2 ... ]`   (list form)
+///   `cFirst cLast w1y vx vy`                         (range form)
+/// where `w1y` is the vertical displacement and `(vx, vy)` the position vector.
+fn parse_cid_w2(file: &PdfFile, dict: &zpdf_core::PdfDict, widths: &mut CidWidths) {
+    if let Some(arr) = resolve_array(file, dict, "W2") {
+        apply_w2_array(&arr, widths);
+    }
+}
+
+fn apply_w2_array(w2_array: &[PdfObject], widths: &mut CidWidths) {
+    let mut i = 0;
+    while i < w2_array.len() {
+        let cid_start = match w2_array[i].as_i64() {
+            Ok(v) => v as u16,
+            Err(_) => break,
+        };
+        i += 1;
+        if i >= w2_array.len() {
+            break;
+        }
+
+        match &w2_array[i] {
+            PdfObject::Array(arr) => {
+                // List form: triples (w1y, vx, vy) starting at cid_start.
+                let mut k = 0;
+                while k + 2 < arr.len() {
+                    let (Ok(w1y), Ok(vx), Ok(vy)) =
+                        (arr[k].as_f64(), arr[k + 1].as_f64(), arr[k + 2].as_f64())
+                    else {
+                        break;
+                    };
+                    let Some(cid) = cid_start.checked_add((k / 3) as u16) else {
+                        break;
+                    };
+                    widths.set_v(cid, w1y, vx, vy);
+                    k += 3;
+                }
+                i += 1;
+            }
+            PdfObject::Integer(_) | PdfObject::Real(_) => {
+                // Range form: cFirst cLast w1y vx vy.
+                let cid_end = w2_array[i].as_i64().unwrap_or(cid_start as i64) as u16;
+                if i + 3 < w2_array.len() {
+                    let (Ok(w1y), Ok(vx), Ok(vy)) = (
+                        w2_array[i + 1].as_f64(),
+                        w2_array[i + 2].as_f64(),
+                        w2_array[i + 3].as_f64(),
+                    ) else {
+                        break;
+                    };
+                    for cid in cid_start..=cid_end {
+                        widths.set_v(cid, w1y, vx, vy);
+                    }
+                    i += 4;
+                } else {
+                    break;
+                }
+            }
+            _ => {
+                i += 1;
+            }
+        }
+    }
+}
+
 fn parse_simple_widths(file: &PdfFile, dict: &zpdf_core::PdfDict) -> CidWidths {
     let first_char = dict.get_i64("FirstChar").unwrap_or(0) as u16;
     let mut widths = CidWidths::new(1000.0);
@@ -688,4 +756,59 @@ fn parse_simple_widths(file: &PdfFile, dict: &zpdf_core::PdfDict) -> CidWidths {
     }
 
     widths
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn int(v: i64) -> PdfObject {
+        PdfObject::Integer(v)
+    }
+    fn real(v: f64) -> PdfObject {
+        PdfObject::Real(v)
+    }
+
+    #[test]
+    fn w2_list_form_assigns_consecutive_cids() {
+        // 120 [w1y vx vy  w1y vx vy] → CIDs 120 and 121.
+        let arr = vec![
+            int(120),
+            PdfObject::Array(vec![
+                real(-1000.0),
+                real(500.0),
+                real(880.0),
+                int(-900),
+                int(450),
+                int(820),
+            ]),
+        ];
+        let mut w = CidWidths::new(1000.0);
+        apply_w2_array(&arr, &mut w);
+        assert_eq!(w.get_v(120), Some((-1000.0, 500.0, 880.0)));
+        assert_eq!(w.get_v(121), Some((-900.0, 450.0, 820.0)));
+        assert_eq!(w.get_v(122), None);
+    }
+
+    #[test]
+    fn w2_range_form_assigns_inclusive_range() {
+        // cFirst cLast w1y vx vy
+        let arr = vec![int(10), int(12), int(-1000), int(500), int(880)];
+        let mut w = CidWidths::new(1000.0);
+        apply_w2_array(&arr, &mut w);
+        for cid in 10..=12 {
+            assert_eq!(w.get_v(cid), Some((-1000.0, 500.0, 880.0)));
+        }
+        assert_eq!(w.get_v(9), None);
+        assert_eq!(w.get_v(13), None);
+    }
+
+    #[test]
+    fn w2_truncated_entry_is_ignored_not_panic() {
+        // Range header without the trailing metric numbers must not panic.
+        let arr = vec![int(10), int(12), int(-1000)];
+        let mut w = CidWidths::new(1000.0);
+        apply_w2_array(&arr, &mut w);
+        assert_eq!(w.get_v(10), None);
+    }
 }

--- a/crates/zpdf-document/src/page.rs
+++ b/crates/zpdf-document/src/page.rs
@@ -78,7 +78,10 @@ impl PdfPage {
             .media_box
             .filter(is_usable_box)
             .unwrap_or(DEFAULT_MEDIA_BOX);
-        let crop_box = inherited.crop_box.filter(is_usable_box).unwrap_or(media_box);
+        let crop_box = inherited
+            .crop_box
+            .filter(is_usable_box)
+            .unwrap_or(media_box);
         let rotate = inherited.rotate.unwrap_or(0);
         let resources = inherited.resources.unwrap_or_default();
 

--- a/crates/zpdf-font/src/lib.rs
+++ b/crates/zpdf-font/src/lib.rs
@@ -26,11 +26,17 @@ pub enum OutlineCommand {
     Close,
 }
 
-/// Per-glyph width from the PDF /W array.
+/// Per-glyph horizontal width from the PDF /W array, plus per-CID vertical
+/// metrics from /W2 (PDF 9.7.4.3) when present.
 #[derive(Debug, Clone)]
 pub struct CidWidths {
     widths: HashMap<u16, f64>,
     default_width: f64,
+    /// /W2 per-CID vertical metrics: cid → (w1y, vx, vy) in 1/1000 glyph-space
+    /// units. `w1y` is the vertical displacement (advance); `(vx, vy)` is the
+    /// position vector of the glyph's vertical-mode origin relative to its
+    /// horizontal-mode origin. Absent CIDs fall back to /DW2.
+    v_metrics: HashMap<u16, (f64, f64, f64)>,
 }
 
 impl CidWidths {
@@ -38,6 +44,7 @@ impl CidWidths {
         Self {
             widths: HashMap::new(),
             default_width,
+            v_metrics: HashMap::new(),
         }
     }
 
@@ -57,6 +64,16 @@ impl CidWidths {
     /// True when no per-glyph widths were set (every code falls to the default).
     pub fn is_empty(&self) -> bool {
         self.widths.is_empty()
+    }
+
+    /// Record a /W2 vertical metric for `cid`: (w1y, vx, vy).
+    pub fn set_v(&mut self, cid: u16, w1y: f64, vx: f64, vy: f64) {
+        self.v_metrics.insert(cid, (w1y, vx, vy));
+    }
+
+    /// Per-CID /W2 vertical metric (w1y, vx, vy), or `None` to fall back to /DW2.
+    pub fn get_v(&self, cid: u16) -> Option<(f64, f64, f64)> {
+        self.v_metrics.get(&cid).copied()
     }
 }
 
@@ -491,6 +508,12 @@ impl LoadedFont {
             }
         }
         self.cid_widths.get(glyph_id)
+    }
+
+    /// Per-CID vertical metric (w1y, vx, vy) from the font's /W2 array, or
+    /// `None` when this CID has no explicit entry (caller uses /DW2).
+    pub fn cid_v_metric(&self, cid: u16) -> Option<(f64, f64, f64)> {
+        self.cid_widths.get_v(cid)
     }
 
     /// The denominator for converting glyph_advance() to user-space units.

--- a/crates/zpdf-image/src/lib.rs
+++ b/crates/zpdf-image/src/lib.rs
@@ -427,11 +427,13 @@ fn decode_jpx_image(
     // some malformed/unusual JPX codestreams; input pre-validation cannot cover
     // all of its internal invariants. Catch the unwind and surface a clean Err
     // so a single bad image is skipped rather than aborting the whole render.
-    let image = catch_unwind(AssertUnwindSafe(|| Image::new(data, &DecodeSettings::default())))
-        .map_err(|_| {
-            Error::StreamDecode("JPXDecode: decoder panicked parsing codestream header".into())
-        })?
-        .map_err(|e| Error::StreamDecode(format!("JPXDecode: {e}")))?;
+    let image = catch_unwind(AssertUnwindSafe(|| {
+        Image::new(data, &DecodeSettings::default())
+    }))
+    .map_err(|_| {
+        Error::StreamDecode("JPXDecode: decoder panicked parsing codestream header".into())
+    })?
+    .map_err(|e| Error::StreamDecode(format!("JPXDecode: {e}")))?;
 
     // Re-check the pixel limit against the *codestream* header dims, which
     // are authoritative and may differ from the dict's /Width × /Height.
@@ -451,26 +453,33 @@ fn decode_jpx_image(
         );
     }
 
-    // Colour channels per pixel (alpha excluded). Codestream-internal ICC
-    // profiles are not applied (channel-count fallback); a PDF-level
-    // /ColorSpace — including a compiled ICCBased transform or an Indexed
-    // palette — overrides below per spec 7.4.9.
+    // Colour channels per pixel (alpha excluded). An ICC profile embedded in
+    // the JP2 codestream is captured here and compiled below (unless a
+    // PDF-level /ColorSpace overrides it per spec 7.4.9).
+    let supported_ncolor = |n: u8| -> Result<usize> {
+        match n {
+            1 => Ok(1),
+            3 => Ok(3),
+            4 => Ok(4),
+            n => Err(Error::StreamDecode(format!(
+                "JPX image with unsupported channel count {n}"
+            ))),
+        }
+    };
+    let mut codestream_icc: Option<Vec<u8>> = None;
     let ncolor = match image.color_space() {
         JpxColorSpace::Gray => 1usize,
         JpxColorSpace::RGB => 3,
         JpxColorSpace::CMYK => 4,
-        JpxColorSpace::Icc { num_channels, .. } | JpxColorSpace::Unknown { num_channels } => {
-            match num_channels {
-                1 => 1,
-                3 => 3,
-                4 => 4,
-                n => {
-                    return Err(Error::StreamDecode(format!(
-                        "JPX image with unsupported channel count {n}"
-                    )))
-                }
-            }
+        JpxColorSpace::Icc {
+            profile,
+            num_channels,
+        } => {
+            let n = supported_ncolor(*num_channels)?;
+            codestream_icc = Some(profile.clone());
+            n
         }
+        JpxColorSpace::Unknown { num_channels } => supported_ncolor(*num_channels)?,
     };
     let has_alpha = image.has_alpha();
     let channels = ncolor + usize::from(has_alpha);
@@ -510,9 +519,42 @@ fn decode_jpx_image(
         }
     });
 
+    // With no overriding PDF /ColorSpace, honour an ICC profile embedded in the
+    // JP2 codestream by compiling it (media-relative colorimetric — the
+    // graphics-state rendering intent is not threaded into image decoding).
+    let codestream_cs = match (override_cs, &codestream_icc) {
+        (None, Some(profile)) => {
+            match zpdf_color::IccTransform::from_profile_bytes(
+                profile,
+                zpdf_color::RenderIntent::default(),
+            ) {
+                Ok(t) if t.components() == ncolor => Some(ResolvedColorSpace::Icc {
+                    ncomp: ncolor as u8,
+                    transform: std::sync::Arc::new(t),
+                }),
+                Ok(t) => {
+                    tracing::warn!(
+                        "JPX codestream ICC has {} components but {ncolor} colour channels; \
+                         using channel-count fallback",
+                        t.components()
+                    );
+                    None
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "JPX codestream ICC profile rejected: {e}; using channel-count fallback"
+                    );
+                    None
+                }
+            }
+        }
+        _ => None,
+    };
+    let effective_cs = override_cs.or(codestream_cs.as_ref());
+
     let mut rgba = Vec::with_capacity(pixel_count as usize * 4);
     for px in samples.chunks_exact(channels).take(pixel_count as usize) {
-        let [mut r, mut g, mut b] = match override_cs {
+        let [mut r, mut g, mut b] = match effective_cs {
             Some(cs) => {
                 let mut comps = [0u8; 4];
                 comps[..ncolor].copy_from_slice(&px[..ncolor]);
@@ -1382,7 +1424,11 @@ mod tests {
     // ---- ICCBased colour spaces (buffer-level CMS transforms) ----
 
     fn icc_cs(profile: &[u8]) -> ResolvedColorSpace {
-        let t = zpdf_color::IccTransform::from_profile_bytes(profile).unwrap();
+        let t = zpdf_color::IccTransform::from_profile_bytes(
+            profile,
+            zpdf_color::RenderIntent::default(),
+        )
+        .unwrap();
         ResolvedColorSpace::Icc {
             ncomp: t.components() as u8,
             transform: std::sync::Arc::new(t),

--- a/crates/zpdf-parser/src/jbig2.rs
+++ b/crates/zpdf-parser/src/jbig2.rs
@@ -1,15 +1,17 @@
 //! JBIG2Decode — ITU-T T.88 bi-level image decoding (embedded PDF profile).
 //!
-//! Pure Rust, zero deps. Implements the arithmetic-coded subset that covers
-//! real-world PDF usage: segment headers, the MQ arithmetic decoder (Annex E),
-//! generic regions (GB templates 0–3, with/without TPGDON), symbol
-//! dictionaries and text regions (refinement and aggregation off), page
+//! Pure Rust, zero deps. Covers the full set of region flavours seen in
+//! real-world PDFs: segment headers, the MQ arithmetic decoder (Annex E),
+//! generic regions (GB templates 0–3, with/without TPGDON), generic refinement
+//! regions (GR templates 0–1, TPGRON), symbol dictionaries (arithmetic and
+//! Huffman, with refinement/aggregation), text regions (arithmetic and Huffman,
+//! with per-instance refinement), pattern dictionaries and halftone regions,
+//! custom and standard Huffman tables (Annex B, tables B.1–B.15), page
 //! assembly, and the PDF embedding rules (optional `/JBIG2Globals` stream
-//! processed first). MMR-coded generic regions reuse the sibling CCITT Group 4
-//! decoder. Unsupported region flavours (halftone, refinement, Huffman-coded)
-//! are skipped with a warning — the region renders blank rather than failing
-//! the whole image; corrupt mandatory structures (segment headers, page info)
-//! are hard errors.
+//! processed first). MMR-coded regions reuse the sibling CCITT Group 4 decoder.
+//! A region that fails to decode renders blank with a warning rather than
+//! failing the whole image; corrupt mandatory structures (segment headers,
+//! page info) are hard errors.
 //!
 //! Output follows the PDF sample convention for 1-bpc images: packed MSB-first
 //! rows of `ceil(width/8)` bytes with **black = 0** / white = 1. JBIG2's
@@ -139,6 +141,32 @@ fn compose_bitmap(dst: &mut Bitmap, src: &Bitmap, x0: usize, y0: usize, op: u8) 
                 2 => *d ^ s,
                 3 => 1 ^ (*d ^ s),
                 _ => s, // REPLACE
+            };
+        }
+    }
+}
+
+/// Place a halftone pattern onto a region bitmap at a possibly-negative origin
+/// with a combination operator (0 = OR, 1 = AND, 2 = XOR, 3 = XNOR, 4 = REPLACE).
+fn place_pattern(dst: &mut Bitmap, pat: &Bitmap, x0: i32, y0: i32, op: u8) {
+    for sy in 0..pat.height as i32 {
+        let py = y0 + sy;
+        if py < 0 || py >= dst.height as i32 {
+            continue;
+        }
+        for sx in 0..pat.width as i32 {
+            let px = x0 + sx;
+            if px < 0 || px >= dst.width as i32 {
+                continue;
+            }
+            let s = pat.data[sy as usize * pat.width + sx as usize];
+            let d = &mut dst.data[py as usize * dst.width + px as usize];
+            *d = match op {
+                0 => *d | s,
+                1 => *d & s,
+                2 => *d ^ s,
+                3 => 1 ^ (*d ^ s),
+                _ => s,
             };
         }
     }
@@ -526,6 +554,855 @@ fn decode_generic(
 }
 
 // ---------------------------------------------------------------------------
+// Generic refinement region decoding (T.88 6.3).
+// ---------------------------------------------------------------------------
+
+/// Parameters for the generic refinement decoder (T.88 6.3.2).
+struct RefinementParams {
+    /// GRTEMPLATE: 0 (13-pixel context, 2 AT pixels) or 1 (10-pixel context).
+    template: u8,
+    /// TPGRON typical-prediction flag.
+    tpgron: bool,
+    /// Adaptive template pixels A1 (current-bitmap offset) and A2 (reference
+    /// offset); only consulted when `template == 0`.
+    at: [(i8, i8); 2],
+    /// Reference bitmap offset: the reference pixel for output (x, y) is the
+    /// reference bitmap at (x - dx, y - dy).
+    dx: i32,
+    dy: i32,
+}
+
+/// Refinement coding/reference template pixels (T.88 6.3.5.3), matching the
+/// canonical bit ordering: the first listed pixel is the most significant bit
+/// of the context. Template 0 appends AT1 to the coding set and AT2 to the
+/// reference set; template 1 has no adaptive pixels.
+///
+/// The context is built coding-pixels-first then reference-pixels, folding left
+/// so the first pixel ends up in the high bit. This matches the SLTP reused
+/// context constants 0x0020 (template 0) and 0x0008 (template 1).
+#[inline]
+#[allow(clippy::too_many_arguments)]
+fn refine_context(
+    template: u8,
+    cur: &Bitmap,
+    refr: &Bitmap,
+    x: i64,
+    y: i64,
+    rx: i64,
+    ry: i64,
+    at: &[(i8, i8); 2],
+) -> usize {
+    let mut ctx = 0usize;
+    if template == 0 {
+        // Coding pixels: (0,-1), (1,-1), (-1,0), then AT1 (nominal (-1,-1)).
+        ctx = (ctx << 1) | cur.get(x, y - 1) as usize;
+        ctx = (ctx << 1) | cur.get(x + 1, y - 1) as usize;
+        ctx = (ctx << 1) | cur.get(x - 1, y) as usize;
+        ctx = (ctx << 1) | cur.get(x + at[0].0 as i64, y + at[0].1 as i64) as usize;
+        // Reference pixels: (0,-1),(1,-1),(-1,0),(0,0),(1,0),(-1,1),(0,1),(1,1),
+        // then AT2 (nominal (-1,-1)).
+        ctx = (ctx << 1) | refr.get(rx, ry - 1) as usize;
+        ctx = (ctx << 1) | refr.get(rx + 1, ry - 1) as usize;
+        ctx = (ctx << 1) | refr.get(rx - 1, ry) as usize;
+        ctx = (ctx << 1) | refr.get(rx, ry) as usize;
+        ctx = (ctx << 1) | refr.get(rx + 1, ry) as usize;
+        ctx = (ctx << 1) | refr.get(rx - 1, ry + 1) as usize;
+        ctx = (ctx << 1) | refr.get(rx, ry + 1) as usize;
+        ctx = (ctx << 1) | refr.get(rx + 1, ry + 1) as usize;
+        ctx = (ctx << 1) | refr.get(rx + at[1].0 as i64, ry + at[1].1 as i64) as usize;
+    } else {
+        // Coding pixels: (-1,-1),(0,-1),(1,-1),(-1,0).
+        ctx = (ctx << 1) | cur.get(x - 1, y - 1) as usize;
+        ctx = (ctx << 1) | cur.get(x, y - 1) as usize;
+        ctx = (ctx << 1) | cur.get(x + 1, y - 1) as usize;
+        ctx = (ctx << 1) | cur.get(x - 1, y) as usize;
+        // Reference pixels: (0,-1),(-1,0),(0,0),(1,0),(0,1),(1,1).
+        ctx = (ctx << 1) | refr.get(rx, ry - 1) as usize;
+        ctx = (ctx << 1) | refr.get(rx - 1, ry) as usize;
+        ctx = (ctx << 1) | refr.get(rx, ry) as usize;
+        ctx = (ctx << 1) | refr.get(rx + 1, ry) as usize;
+        ctx = (ctx << 1) | refr.get(rx, ry + 1) as usize;
+        ctx = (ctx << 1) | refr.get(rx + 1, ry + 1) as usize;
+    }
+    ctx
+}
+
+/// Decode a generic refinement region (T.88 6.3.5). `cx` must hold at least
+/// `1 << 13` contexts and is shared across calls within one segment.
+fn decode_refinement(
+    mq: &mut MqDecoder,
+    cx: &mut [u8],
+    width: usize,
+    height: usize,
+    refr: &Bitmap,
+    p: &RefinementParams,
+) -> Result<Bitmap> {
+    let mut bm = Bitmap::new(width, height, 0)?;
+    let mut ltp = false;
+    for y in 0..height as i64 {
+        if p.tpgron {
+            // SLTP reused context (T.88 6.3.5.6): the pseudo-pixel context for
+            // the canonical bit ordering is 0x0020 (template 0) / 0x0008
+            // (template 1).
+            let sltp_cx = if p.template == 0 { 0x0020 } else { 0x0008 };
+            ltp ^= mq.decode(cx, sltp_cx) == 1;
+        }
+        for x in 0..width as i64 {
+            let rx = x - p.dx as i64;
+            let ry = y - p.dy as i64;
+            if ltp {
+                // Typical prediction: a uniform 3x3 reference neighbourhood
+                // makes the output pixel equal the reference pixel without
+                // coding it (T.88 6.3.5.6).
+                let mut sum = 0i32;
+                for ddy in -1..=1 {
+                    for ddx in -1..=1 {
+                        sum += refr.get(rx + ddx, ry + ddy) as i32;
+                    }
+                }
+                if sum == 0 {
+                    continue; // all-white neighbourhood → pixel stays 0
+                }
+                if sum == 9 {
+                    bm.set(x as usize, y as usize, 1);
+                    continue;
+                }
+            }
+            let ctx = refine_context(p.template, &bm, refr, x, y, rx, ry, &p.at);
+            if mq.decode(cx, ctx) == 1 {
+                bm.set(x as usize, y as usize, 1);
+            }
+        }
+    }
+    Ok(bm)
+}
+
+// ---------------------------------------------------------------------------
+// Text region core (T.88 6.4) — shared by standalone text regions and the
+// symbol-dictionary aggregate case.
+// ---------------------------------------------------------------------------
+
+/// Text-region geometry and placement flags, decoupled from the entropy coder
+/// so the arithmetic and Huffman paths and the symbol-dict aggregate case all
+/// share one placement loop.
+struct TextRegionGeom {
+    /// SBSTRIPS = 1 << log_strips.
+    log_strips: u32,
+    strips: i64,
+    /// Reference corner: 0 = BL, 1 = TL, 2 = BR, 3 = TR.
+    ref_corner: u8,
+    transposed: bool,
+    comb_op: u8,
+    def_pixel: u8,
+    ds_offset: i64,
+    sb_refine: bool,
+    r_template: u8,
+    r_at: [(i8, i8); 2],
+}
+
+impl TextRegionGeom {
+    /// The implicit geometry used when a symbol dictionary aggregates symbols
+    /// (T.88 6.5.8.2.2): SBSTRIPS = 1, TOPLEFT, OR, refinement on.
+    fn aggregate(r_template: u8, r_at: [(i8, i8); 2]) -> Self {
+        Self {
+            log_strips: 0,
+            strips: 1,
+            ref_corner: 1, // TOPLEFT
+            transposed: false,
+            comb_op: 0, // OR
+            def_pixel: 0,
+            ds_offset: 0,
+            sb_refine: true,
+            r_template,
+            r_at,
+        }
+    }
+}
+
+/// Mutable arithmetic integer-context bundle for the text-region core.
+struct TextArithCtx<'a> {
+    iadt: &'a mut [u8],
+    iafs: &'a mut [u8],
+    iads: &'a mut [u8],
+    iait: &'a mut [u8],
+    iari: &'a mut [u8],
+    iardw: &'a mut [u8],
+    iardh: &'a mut [u8],
+    iardx: &'a mut [u8],
+    iardy: &'a mut [u8],
+    iaid: &'a mut [u8],
+    cx_gr: &'a mut [u8],
+}
+
+/// Place one symbol instance onto the region bitmap, applying per-instance
+/// refinement if requested. Returns the advance along the S axis.
+#[allow(clippy::too_many_arguments)]
+fn place_instance(
+    bm: &mut Bitmap,
+    sym: &Bitmap,
+    refined: Option<Bitmap>,
+    t: i64,
+    curs: i64,
+    geom: &TextRegionGeom,
+) -> i64 {
+    let placed = refined.as_ref().unwrap_or(sym);
+    let (w, hh) = (placed.width as i64, placed.height as i64);
+    if !geom.transposed {
+        let y0 = t - if geom.ref_corner & 1 == 0 { hh - 1 } else { 0 };
+        let x0 = curs;
+        draw_symbol(bm, placed, x0, y0, geom.comb_op);
+        w - 1
+    } else {
+        let x0 = t - if geom.ref_corner & 2 != 0 { w - 1 } else { 0 };
+        let y0 = curs;
+        draw_symbol(bm, placed, x0, y0, geom.comb_op);
+        hh - 1
+    }
+}
+
+/// Arithmetic text-region core (T.88 6.4.5). Decodes `num_instances` placements
+/// off the live MQ stream and returns the region bitmap.
+#[allow(clippy::too_many_arguments)]
+fn decode_text_region_arith(
+    mq: &mut MqDecoder,
+    width: usize,
+    height: usize,
+    symbols: &[Rc<Bitmap>],
+    num_instances: usize,
+    sym_code_len: u32,
+    geom: &TextRegionGeom,
+    ctx: &mut TextArithCtx,
+) -> Result<Bitmap> {
+    let mut bm = Bitmap::new(width, height, geom.def_pixel)?;
+    let strips = geom.strips;
+
+    let mut stript =
+        -decode_int(mq, ctx.iadt).ok_or_else(|| err("unexpected OOB in IADT"))? * strips;
+    let mut firsts: i64 = 0;
+    let mut inst = 0usize;
+
+    'instances: while inst < num_instances {
+        let dt = decode_int(mq, ctx.iadt).ok_or_else(|| err("unexpected OOB in IADT"))?;
+        stript += dt * strips;
+        let dfs = decode_int(mq, ctx.iafs).ok_or_else(|| err("unexpected OOB in IAFS"))?;
+        firsts += dfs;
+        let mut curs = firsts;
+        let mut first = true;
+        loop {
+            if !first {
+                let Some(ids) = decode_int(mq, ctx.iads) else {
+                    break; // OOB ends the strip
+                };
+                curs += ids + geom.ds_offset;
+            }
+            first = false;
+            if inst >= num_instances {
+                break 'instances;
+            }
+
+            let curt = if strips == 1 {
+                0
+            } else {
+                decode_int(mq, ctx.iait).ok_or_else(|| err("unexpected OOB in IAIT"))?
+            };
+            let t = stript + curt;
+            let id = decode_iaid(mq, ctx.iaid, sym_code_len);
+            let sym = symbols
+                .get(id)
+                .ok_or_else(|| err(format!("symbol id {id} out of range")))?
+                .clone();
+
+            // Per-instance refinement (T.88 6.4.11).
+            let refined = if geom.sb_refine {
+                let ri = decode_int(mq, ctx.iari).ok_or_else(|| err("unexpected OOB in IARI"))?;
+                if ri != 0 {
+                    let rdw =
+                        decode_int(mq, ctx.iardw).ok_or_else(|| err("unexpected OOB in IARDW"))?;
+                    let rdh =
+                        decode_int(mq, ctx.iardh).ok_or_else(|| err("unexpected OOB in IARDH"))?;
+                    let rdx =
+                        decode_int(mq, ctx.iardx).ok_or_else(|| err("unexpected OOB in IARDX"))?;
+                    let rdy =
+                        decode_int(mq, ctx.iardy).ok_or_else(|| err("unexpected OOB in IARDY"))?;
+                    let nw = sym.width as i64 + rdw;
+                    let nh = sym.height as i64 + rdh;
+                    if nw <= 0 || nh <= 0 || nw > MAX_DIMENSION as i64 || nh > MAX_DIMENSION as i64
+                    {
+                        return Err(err("implausible refined symbol size"));
+                    }
+                    // The reference offset (T.88 6.4.11): floor(RDW/2)+RDX,
+                    // floor(RDH/2)+RDY.
+                    let dx = (rdw >> 1) + rdx;
+                    let dy = (rdh >> 1) + rdy;
+                    Some(decode_refinement(
+                        mq,
+                        ctx.cx_gr,
+                        nw as usize,
+                        nh as usize,
+                        &sym,
+                        &RefinementParams {
+                            template: geom.r_template,
+                            tpgron: false,
+                            at: geom.r_at,
+                            dx: dx as i32,
+                            dy: dy as i32,
+                        },
+                    )?)
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
+
+            curs += place_instance(&mut bm, &sym, refined, t, curs, geom);
+            inst += 1;
+        }
+    }
+    Ok(bm)
+}
+
+// ---------------------------------------------------------------------------
+// Huffman decoding (T.88 Annex B).
+// ---------------------------------------------------------------------------
+
+/// MSB-first bit reader over the entropy payload. Past the end it yields 0
+/// bits (Huffman streams declare their own counts, so reads stay bounded).
+struct BitReader<'a> {
+    data: &'a [u8],
+    /// Next bit position, counted in bits from the start of `data`.
+    pos: usize,
+}
+
+impl<'a> BitReader<'a> {
+    fn new(data: &'a [u8]) -> Self {
+        Self { data, pos: 0 }
+    }
+
+    #[inline]
+    fn read_bit(&mut self) -> u32 {
+        let byte = self.pos >> 3;
+        let bit = 7 - (self.pos & 7);
+        self.pos += 1;
+        match self.data.get(byte) {
+            Some(&b) => ((b >> bit) & 1) as u32,
+            None => 0,
+        }
+    }
+
+    /// Read `n` bits MSB-first (n ≤ 32).
+    fn read_bits(&mut self, n: u32) -> u32 {
+        let mut v = 0u32;
+        for _ in 0..n {
+            v = (v << 1) | self.read_bit();
+        }
+        v
+    }
+
+    /// Skip to the next byte boundary (used at the end of a Huffman region).
+    fn byte_align(&mut self) {
+        self.pos = self.pos.div_ceil(8) * 8;
+    }
+
+    /// Current byte offset (rounded up), used to locate trailing MMR/BMSIZE
+    /// payloads inside a Huffman symbol dictionary.
+    fn byte_pos(&self) -> usize {
+        self.pos.div_ceil(8)
+    }
+}
+
+/// One Huffman table line (T.88 B.4): a prefix length, a range length and a
+/// range low value, plus flags for the lower-range and OOB line kinds.
+#[derive(Clone, Copy)]
+struct HuffLine {
+    prefix_len: u8,
+    range_len: u8,
+    range_low: i32,
+    /// Lower-range line: the magnitude is subtracted from `range_low`.
+    is_lower: bool,
+    /// Out-of-band line (HUFFDEC returns OOB).
+    is_oob: bool,
+}
+
+impl HuffLine {
+    const fn normal(prefix_len: u8, range_len: u8, range_low: i32) -> Self {
+        Self {
+            prefix_len,
+            range_len,
+            range_low,
+            is_lower: false,
+            is_oob: false,
+        }
+    }
+    const fn lower(prefix_len: u8, range_len: u8, range_low: i32) -> Self {
+        Self {
+            prefix_len,
+            range_len,
+            range_low,
+            is_lower: true,
+            is_oob: false,
+        }
+    }
+    const fn upper(prefix_len: u8, range_len: u8, range_low: i32) -> Self {
+        // Upper range line: 32-bit magnitude added to range_low (B.5 reserves
+        // this for the highest line; encoded identically to a normal line).
+        Self::normal(prefix_len, range_len, range_low)
+    }
+    const fn oob(prefix_len: u8) -> Self {
+        Self {
+            prefix_len,
+            range_len: 0,
+            range_low: 0,
+            is_lower: false,
+            is_oob: true,
+        }
+    }
+}
+
+/// A built Huffman table: lines paired with assigned prefix codes (T.88 B.3).
+struct HuffTable {
+    lines: Vec<HuffLine>,
+    /// Assigned prefix code per line, parallel to `lines`. Lines with
+    /// `prefix_len == 0` are unused and carry an unreachable code.
+    codes: Vec<u32>,
+}
+
+impl HuffTable {
+    /// Assign prefix codes from the lines' prefix lengths (T.88 B.3).
+    fn build(lines: Vec<HuffLine>) -> Result<Self> {
+        let max_len = lines.iter().map(|l| l.prefix_len).max().unwrap_or(0) as usize;
+        if max_len == 0 {
+            return Ok(Self {
+                codes: vec![0; lines.len()],
+                lines,
+            });
+        }
+        if max_len > 32 {
+            return Err(err("Huffman prefix length exceeds 32 bits"));
+        }
+        let mut len_count = vec![0u32; max_len + 1];
+        for l in &lines {
+            len_count[l.prefix_len as usize] += 1;
+        }
+        len_count[0] = 0;
+        // First code per length (T.88 B.3 step 3).
+        let mut first_code = vec![0u32; max_len + 2];
+        let mut curcode = 0u32;
+        for len in 1..=max_len {
+            first_code[len] = curcode;
+            curcode = (curcode + len_count[len]) << 1;
+        }
+        let mut next = first_code.clone();
+        let mut codes = vec![0u32; lines.len()];
+        for (i, l) in lines.iter().enumerate() {
+            let len = l.prefix_len as usize;
+            if len > 0 {
+                codes[i] = next[len];
+                next[len] += 1;
+            }
+        }
+        Ok(Self { lines, codes })
+    }
+
+    /// HUFFDEC (T.88 B.2): read a value or OOB. Returns `None` for OOB.
+    fn decode(&self, br: &mut BitReader) -> Option<i64> {
+        let mut len = 0u32;
+        let mut code = 0u32;
+        // Bound the prefix scan by the longest assigned length plus slack so a
+        // corrupt stream cannot loop forever.
+        let max_len = self.lines.iter().map(|l| l.prefix_len).max().unwrap_or(0) as u32;
+        while len <= max_len + 1 {
+            code = (code << 1) | br.read_bit();
+            len += 1;
+            for (i, l) in self.lines.iter().enumerate() {
+                if l.prefix_len as u32 == len && self.codes[i] == code {
+                    if l.is_oob {
+                        return None;
+                    }
+                    if l.range_len == 32 {
+                        // (Upper/lower) 32-bit range line.
+                        let mag = br.read_bits(32) as i64;
+                        return Some(if l.is_lower {
+                            l.range_low as i64 - mag
+                        } else {
+                            l.range_low as i64 + mag
+                        });
+                    }
+                    let mag = br.read_bits(l.range_len as u32) as i64;
+                    return Some(if l.is_lower {
+                        l.range_low as i64 - mag
+                    } else {
+                        l.range_low as i64 + mag
+                    });
+                }
+            }
+        }
+        // No prefix matched (corrupt table or stream): treat as OOB so the
+        // caller's bounded loop terminates rather than spinning.
+        None
+    }
+}
+
+/// Standard Huffman table B.`n` (1-based, T.88 Annex B.5 tables B.1–B.15).
+fn standard_huff_table(n: usize) -> HuffTable {
+    use HuffLine as L;
+    let lines: Vec<HuffLine> = match n {
+        1 => vec![
+            L::normal(1, 4, 0),
+            L::normal(2, 8, 16),
+            L::normal(3, 16, 272),
+            L::upper(3, 32, 65808),
+        ],
+        2 => vec![
+            L::normal(1, 0, 0),
+            L::normal(2, 0, 1),
+            L::normal(3, 0, 2),
+            L::normal(4, 3, 3),
+            L::normal(5, 6, 11),
+            L::upper(6, 32, 75),
+            L::oob(6),
+        ],
+        3 => vec![
+            L::normal(8, 8, -256),
+            L::normal(1, 0, 0),
+            L::normal(2, 0, 1),
+            L::normal(3, 0, 2),
+            L::normal(4, 3, 3),
+            L::normal(5, 6, 11),
+            L::lower(8, 32, -257),
+            L::upper(7, 32, 75),
+            L::oob(6),
+        ],
+        4 => vec![
+            L::normal(1, 0, 1),
+            L::normal(2, 0, 2),
+            L::normal(3, 0, 3),
+            L::normal(4, 3, 4),
+            L::normal(5, 6, 12),
+            L::upper(5, 32, 76),
+        ],
+        5 => vec![
+            L::normal(7, 8, -255),
+            L::normal(1, 0, 1),
+            L::normal(2, 0, 2),
+            L::normal(3, 0, 3),
+            L::normal(4, 3, 4),
+            L::normal(5, 6, 12),
+            L::lower(7, 32, -256),
+            L::upper(6, 32, 76),
+        ],
+        6 => vec![
+            L::normal(5, 10, -2048),
+            L::normal(4, 9, -1024),
+            L::normal(4, 8, -512),
+            L::normal(4, 7, -256),
+            L::normal(5, 6, -128),
+            L::normal(5, 5, -64),
+            L::normal(4, 5, -32),
+            L::normal(2, 7, 0),
+            L::normal(3, 7, 128),
+            L::normal(3, 8, 256),
+            L::normal(4, 9, 512),
+            L::normal(4, 10, 1024),
+            L::lower(6, 32, -2049),
+            L::upper(6, 32, 2048),
+        ],
+        7 => vec![
+            L::normal(4, 9, -1024),
+            L::normal(3, 8, -512),
+            L::normal(4, 7, -256),
+            L::normal(5, 6, -128),
+            L::normal(5, 5, -64),
+            L::normal(4, 5, -32),
+            L::normal(4, 5, 0),
+            L::normal(5, 5, 32),
+            L::normal(5, 6, 64),
+            L::normal(4, 7, 128),
+            L::normal(3, 8, 256),
+            L::normal(3, 9, 512),
+            L::normal(3, 10, 1024),
+            L::lower(5, 32, -1025),
+            L::upper(5, 32, 2048),
+        ],
+        8 => vec![
+            L::normal(8, 3, -15),
+            L::normal(9, 1, -7),
+            L::normal(8, 1, -5),
+            L::normal(9, 0, -3),
+            L::normal(7, 0, -2),
+            L::normal(4, 0, -1),
+            L::normal(2, 1, 0),
+            L::normal(5, 0, 2),
+            L::normal(6, 0, 3),
+            L::normal(3, 4, 4),
+            L::normal(6, 1, 20),
+            L::normal(4, 4, 22),
+            L::normal(4, 5, 38),
+            L::normal(5, 6, 70),
+            L::normal(5, 7, 134),
+            L::normal(6, 7, 262),
+            L::normal(7, 8, 390),
+            L::normal(6, 10, 646),
+            L::lower(9, 32, -16),
+            L::upper(9, 32, 1670),
+            L::oob(2),
+        ],
+        9 => vec![
+            L::normal(8, 4, -31),
+            L::normal(9, 2, -15),
+            L::normal(8, 2, -11),
+            L::normal(9, 1, -7),
+            L::normal(7, 1, -5),
+            L::normal(4, 1, -3),
+            L::normal(3, 1, -1),
+            L::normal(3, 1, 1),
+            L::normal(5, 1, 3),
+            L::normal(6, 1, 5),
+            L::normal(3, 5, 7),
+            L::normal(6, 2, 39),
+            L::normal(4, 5, 43),
+            L::normal(4, 6, 75),
+            L::normal(5, 7, 139),
+            L::normal(5, 8, 267),
+            L::normal(6, 8, 523),
+            L::normal(7, 9, 779),
+            L::normal(6, 11, 1291),
+            L::lower(9, 32, -32),
+            L::upper(9, 32, 3339),
+            L::oob(2),
+        ],
+        10 => vec![
+            L::normal(7, 4, -21),
+            L::normal(8, 0, -5),
+            L::normal(7, 0, -4),
+            L::normal(5, 0, -3),
+            L::normal(2, 2, -2),
+            L::normal(5, 0, 2),
+            L::normal(6, 0, 3),
+            L::normal(7, 0, 4),
+            L::normal(8, 0, 5),
+            L::normal(2, 6, 6),
+            L::normal(5, 5, 70),
+            L::normal(6, 5, 102),
+            L::normal(6, 6, 134),
+            L::normal(6, 7, 198),
+            L::normal(6, 8, 326),
+            L::normal(6, 9, 582),
+            L::normal(6, 10, 1094),
+            L::normal(7, 11, 2118),
+            L::lower(8, 32, -22),
+            L::upper(8, 32, 4166),
+            L::oob(2),
+        ],
+        11 => vec![
+            L::normal(1, 0, 1),
+            L::normal(2, 1, 2),
+            L::normal(4, 0, 4),
+            L::normal(4, 1, 5),
+            L::normal(5, 1, 7),
+            L::normal(5, 2, 9),
+            L::normal(6, 2, 13),
+            L::normal(7, 2, 17),
+            L::normal(7, 3, 21),
+            L::normal(7, 4, 29),
+            L::normal(7, 5, 45),
+            L::normal(7, 6, 77),
+            L::upper(7, 32, 141),
+        ],
+        12 => vec![
+            L::normal(1, 0, 1),
+            L::normal(2, 0, 2),
+            L::normal(3, 1, 3),
+            L::normal(5, 0, 5),
+            L::normal(5, 1, 6),
+            L::normal(6, 1, 8),
+            L::normal(7, 0, 10),
+            L::normal(7, 1, 11),
+            L::normal(7, 2, 13),
+            L::normal(7, 3, 17),
+            L::normal(7, 4, 25),
+            L::normal(8, 5, 41),
+            L::upper(8, 32, 73),
+        ],
+        13 => vec![
+            L::normal(1, 0, 1),
+            L::normal(3, 0, 2),
+            L::normal(4, 0, 3),
+            L::normal(5, 0, 4),
+            L::normal(4, 1, 5),
+            L::normal(3, 3, 7),
+            L::normal(6, 1, 15),
+            L::normal(6, 2, 17),
+            L::normal(6, 3, 21),
+            L::normal(6, 4, 29),
+            L::normal(6, 5, 45),
+            L::normal(7, 6, 77),
+            L::upper(7, 32, 141),
+        ],
+        14 => vec![
+            L::normal(3, 0, -2),
+            L::normal(3, 0, -1),
+            L::normal(1, 0, 0),
+            L::normal(3, 0, 1),
+            L::normal(3, 0, 2),
+        ],
+        15 => vec![
+            L::normal(7, 4, -24),
+            L::normal(6, 2, -8),
+            L::normal(5, 1, -4),
+            L::normal(4, 0, -2),
+            L::normal(3, 0, -1),
+            L::normal(1, 0, 0),
+            L::normal(3, 0, 1),
+            L::normal(4, 0, 2),
+            L::normal(5, 1, 3),
+            L::normal(6, 2, 5),
+            L::normal(7, 4, 9),
+            L::lower(7, 32, -25),
+            L::upper(7, 32, 25),
+        ],
+        _ => vec![L::normal(1, 0, 0)],
+    };
+    HuffTable::build(lines).expect("standard Huffman table is well-formed")
+}
+
+/// Build a custom Huffman table from a type-53 segment (T.88 B.2 / 7.4.5).
+fn parse_custom_huff_table(data: &[u8]) -> Result<HuffTable> {
+    let mut r = Reader::new(data);
+    let flags = r.u8()?;
+    let oob = flags & 1 != 0;
+    let prefix_size = (((flags >> 1) & 7) + 1) as u32;
+    let range_size = (((flags >> 4) & 7) + 1) as u32;
+    let low = r.u32()? as i32;
+    let high = r.u32()? as i32;
+    if high < low {
+        return Err(err("Huffman table HIGH < LOW"));
+    }
+    let mut br = BitReader::new(r.rest());
+    let mut lines = Vec::new();
+    let mut cur = low;
+    // Normal lines until cur reaches HIGH (T.88 B.2 step 4).
+    let mut guard = 0;
+    while cur < high {
+        let prefix_len = br.read_bits(prefix_size) as u8;
+        let range_len = br.read_bits(range_size) as u8;
+        lines.push(HuffLine::normal(prefix_len, range_len, cur));
+        // Avoid overflow: range_len up to 32.
+        cur = cur.saturating_add(1i32.checked_shl(range_len as u32).unwrap_or(i32::MAX));
+        guard += 1;
+        if guard > MAX_SYMBOLS {
+            return Err(err("custom Huffman table has too many lines"));
+        }
+    }
+    // Lower-range line.
+    let lower_prefix = br.read_bits(prefix_size) as u8;
+    lines.push(HuffLine::lower(lower_prefix, 32, low - 1));
+    // Upper-range line.
+    let upper_prefix = br.read_bits(prefix_size) as u8;
+    lines.push(HuffLine::normal(upper_prefix, 32, high));
+    // Optional OOB line.
+    if oob {
+        let oob_prefix = br.read_bits(prefix_size) as u8;
+        lines.push(HuffLine::oob(oob_prefix));
+    }
+    HuffTable::build(lines)
+}
+
+/// A runtime-selectable Huffman table: a standard table or a borrowed custom
+/// one resolved from the region's referred type-53 segments.
+enum HuffSel<'a> {
+    Std(HuffTable),
+    Custom(&'a HuffTable),
+}
+
+impl HuffSel<'_> {
+    fn table(&self) -> &HuffTable {
+        match self {
+            HuffSel::Std(t) => t,
+            HuffSel::Custom(t) => t,
+        }
+    }
+}
+
+/// Read the runtime symbol-ID Huffman table for a Huffman text region
+/// (T.88 7.4.4.1.4). First 35 run-code lengths (4 bits each) build a run-code
+/// table; that table then decodes `n_syms` code lengths, with run codes 32–34
+/// expanding to repeat counts. The result is a Huffman table mapping codes to
+/// symbol indices 0..n_syms.
+fn read_symbol_id_huff_table(br: &mut BitReader, n_syms: usize) -> Result<HuffTable> {
+    // 35 run-code prefix lengths.
+    let mut runcode_lines = Vec::with_capacity(35);
+    for i in 0..35i32 {
+        let len = br.read_bits(4) as u8;
+        runcode_lines.push(HuffLine::normal(len, 0, i));
+    }
+    let runcode_tab = HuffTable::build(runcode_lines)?;
+
+    // Decode n_syms symbol code lengths.
+    let mut code_lengths = vec![0u8; n_syms];
+    let mut prev_len = 0i64;
+    let mut i = 0usize;
+    let mut guard = 0usize;
+    while i < n_syms {
+        guard += 1;
+        if guard > n_syms.saturating_add(64).saturating_mul(4) {
+            return Err(err("symbol ID Huffman table failed to terminate"));
+        }
+        let code = runcode_tab
+            .decode(br)
+            .ok_or_else(|| err("OOB decoding symbol ID run code"))?;
+        match code {
+            0..=31 => {
+                code_lengths[i] = code as u8;
+                prev_len = code;
+                i += 1;
+            }
+            32 => {
+                // Repeat the previous length 3..=6 times.
+                let rep = br.read_bits(2) as usize + 3;
+                for _ in 0..rep {
+                    if i >= n_syms {
+                        break;
+                    }
+                    code_lengths[i] = prev_len as u8;
+                    i += 1;
+                }
+            }
+            33 => {
+                // Repeat length 0, 3..=10 times.
+                let rep = br.read_bits(3) as usize + 3;
+                for _ in 0..rep {
+                    if i >= n_syms {
+                        break;
+                    }
+                    code_lengths[i] = 0;
+                    i += 1;
+                }
+            }
+            34 => {
+                // Repeat length 0, 11..=138 times.
+                let rep = br.read_bits(7) as usize + 11;
+                for _ in 0..rep {
+                    if i >= n_syms {
+                        break;
+                    }
+                    code_lengths[i] = 0;
+                    i += 1;
+                }
+            }
+            _ => return Err(err("invalid symbol ID run code")),
+        }
+    }
+
+    let lines: Vec<HuffLine> = code_lengths
+        .iter()
+        .enumerate()
+        .map(|(idx, &len)| HuffLine::normal(len, 0, idx as i32))
+        .collect();
+    HuffTable::build(lines)
+}
+
+// ---------------------------------------------------------------------------
 // Segment headers (T.88 7.2).
 // ---------------------------------------------------------------------------
 
@@ -648,6 +1525,7 @@ fn parse_segment_header(r: &mut Reader) -> Result<SegmentHeader> {
 
 /// Region segment information field (T.88 7.4.1): geometry plus the external
 /// combination operator.
+#[derive(Clone)]
 struct RegionInfo {
     width: usize,
     height: usize,
@@ -680,6 +1558,11 @@ fn parse_region_info(r: &mut Reader) -> Result<RegionInfo> {
 // Segment processing and page assembly.
 // ---------------------------------------------------------------------------
 
+/// A decoded pattern dictionary (T.88 6.7): HDPW×HDPH patterns indexed 0..=HDMAX.
+struct PatternDict {
+    patterns: Vec<Rc<Bitmap>>,
+}
+
 #[derive(Default)]
 struct Decoder {
     page: Option<Bitmap>,
@@ -689,6 +1572,14 @@ struct Decoder {
     /// Exported symbols per symbol-dictionary segment number; `None` records
     /// a dictionary that failed to decode (dependent regions render blank).
     symbol_dicts: HashMap<u32, Option<Vec<Rc<Bitmap>>>>,
+    /// Intermediate region bitmaps keyed by segment number (types 4/20/36/40/42),
+    /// with their region geometry, for use as refinement references and for
+    /// the (rare) referred-intermediate case.
+    regions: HashMap<u32, (RegionInfo, Bitmap)>,
+    /// Pattern dictionaries keyed by segment number (type 16).
+    pattern_dicts: HashMap<u32, Option<PatternDict>>,
+    /// Custom Huffman tables keyed by type-53 segment number.
+    huff_tables: HashMap<u32, HuffTable>,
 }
 
 impl Decoder {
@@ -740,19 +1631,76 @@ impl Decoder {
                 };
                 self.symbol_dicts.insert(h.number, dict);
             }
-            // Immediate (lossless) text region.
-            6 | 7 => match self.decode_text_region(h, data) {
-                Ok((info, bm)) => self.compose_to_page(&info, &bm)?,
+            // Text region: intermediate (4) is stored; immediate (6/7) composes.
+            4 | 6 | 7 => match self.decode_text_region(h, data) {
+                Ok((info, bm)) => {
+                    if h.seg_type == 4 {
+                        self.regions.insert(h.number, (info, bm));
+                    } else {
+                        self.compose_to_page(&info, &bm)?;
+                    }
+                }
                 Err(e) => warn!(
                     "JBIG2Decode: text region segment {} failed ({e}); region left blank",
                     h.number
                 ),
             },
-            // Immediate (lossless) generic region.
-            38 | 39 => match self.decode_generic_region_segment(data) {
-                Ok((info, bm)) => self.compose_to_page(&info, &bm)?,
+            // Generic region: intermediate (36) stored; immediate (38/39) composes.
+            36 | 38 | 39 => match self.decode_generic_region_segment(data) {
+                Ok((info, bm)) => {
+                    if h.seg_type == 36 {
+                        self.regions.insert(h.number, (info, bm));
+                    } else {
+                        self.compose_to_page(&info, &bm)?;
+                    }
+                }
                 Err(e) => warn!(
                     "JBIG2Decode: generic region segment {} failed ({e}); region left blank",
+                    h.number
+                ),
+            },
+            // Generic refinement region: intermediate (40) stored; immediate
+            // (42/43) composes. The reference is a referred intermediate region
+            // or, by default, the page area at the region's location.
+            40 | 42 | 43 => match self.decode_refinement_region_segment(h, data) {
+                Ok((info, bm)) => {
+                    if h.seg_type == 40 {
+                        self.regions.insert(h.number, (info, bm));
+                    } else {
+                        self.compose_to_page(&info, &bm)?;
+                    }
+                }
+                Err(e) => warn!(
+                    "JBIG2Decode: refinement region segment {} failed ({e}); region left blank",
+                    h.number
+                ),
+            },
+            // Pattern dictionary: cache by segment number.
+            16 => {
+                let pd = match self.decode_pattern_dict(data) {
+                    Ok(d) => Some(d),
+                    Err(e) => {
+                        warn!(
+                            "JBIG2Decode: pattern dictionary segment {} failed ({e}); \
+                             dependent halftone regions will be blank",
+                            h.number
+                        );
+                        None
+                    }
+                };
+                self.pattern_dicts.insert(h.number, pd);
+            }
+            // Halftone region: intermediate (20) stored; immediate (22/23) composes.
+            20 | 22 | 23 => match self.decode_halftone_region(h, data) {
+                Ok((info, bm)) => {
+                    if h.seg_type == 20 {
+                        self.regions.insert(h.number, (info, bm));
+                    } else {
+                        self.compose_to_page(&info, &bm)?;
+                    }
+                }
+                Err(e) => warn!(
+                    "JBIG2Decode: halftone region segment {} failed ({e}); region left blank",
                     h.number
                 ),
             },
@@ -760,18 +1708,16 @@ impl Decoder {
             50 => self.process_end_of_stripe(data)?,
             // End of page / end of file / profiles / extensions: no action.
             49 | 51 | 52 | 62 => {}
-            // Intermediate regions and refinement regions are not supported.
-            4 | 36 | 40..=43 => warn!(
-                "JBIG2Decode: unsupported region segment type {} ignored (region blank)",
-                h.seg_type
-            ),
-            // Pattern dictionaries and halftone regions are not supported.
-            16 | 20 | 22 | 23 => warn!(
-                "JBIG2Decode: halftone segment type {} ignored (region blank)",
-                h.seg_type
-            ),
-            // Custom Huffman tables only matter to (unsupported) Huffman coding.
-            53 => debug!("JBIG2Decode: Huffman table segment ignored"),
+            // Custom Huffman table segment (T.88 7.4.5): parse and cache.
+            53 => match parse_custom_huff_table(data) {
+                Ok(t) => {
+                    self.huff_tables.insert(h.number, t);
+                }
+                Err(e) => warn!(
+                    "JBIG2Decode: custom Huffman table segment {} failed ({e}); ignored",
+                    h.number
+                ),
+            },
             other => warn!("JBIG2Decode: unknown segment type {other} ignored"),
         }
         Ok(())
@@ -897,28 +1843,112 @@ impl Decoder {
         Ok((info, bm))
     }
 
-    /// Symbol dictionary segment (T.88 6.5 / 7.4.3), arithmetic coding only.
+    /// Generic refinement region segment (T.88 7.4.7). The reference bitmap is
+    /// a referred intermediate region (if exactly one is referred) or the
+    /// current page contents at the region's location.
+    fn decode_refinement_region_segment(
+        &self,
+        h: &SegmentHeader,
+        data: &[u8],
+    ) -> Result<(RegionInfo, Bitmap)> {
+        let mut r = Reader::new(data);
+        let info = parse_region_info(&mut r)?;
+        let flags = r.u8()?;
+        let template = flags & 1;
+        let tpgron = flags & 2 != 0;
+
+        let mut at = [(0i8, 0i8); 2];
+        if template == 0 {
+            at[0] = (r.i8()?, r.i8()?);
+            at[1] = (r.i8()?, r.i8()?);
+        }
+
+        // Locate the reference: a referred region segment, else the page.
+        let refr: Bitmap =
+            if let Some(num) = h.referred.iter().find(|n| self.regions.contains_key(n)) {
+                let (_rinfo, rbm) = &self.regions[num];
+                rbm.clone()
+            } else {
+                let page = self
+                    .page
+                    .as_ref()
+                    .ok_or_else(|| err("refinement region with no page reference"))?;
+                let mut refr = Bitmap::new(info.width, info.height, 0)?;
+                for y in 0..info.height {
+                    for x in 0..info.width {
+                        let v = page.get((info.x + x) as i64, (info.y + y) as i64);
+                        if v != 0 {
+                            refr.set(x, y, 1);
+                        }
+                    }
+                }
+                refr
+            };
+
+        let mut mq = MqDecoder::new(r.rest());
+        let mut cx = vec![0u8; 1 << 13];
+        let bm = decode_refinement(
+            &mut mq,
+            &mut cx,
+            info.width,
+            info.height,
+            &refr,
+            &RefinementParams {
+                template,
+                tpgron,
+                at,
+                dx: 0,
+                dy: 0,
+            },
+        )?;
+        // When refining the page in place, the result REPLACES the page area
+        // (operator REPLACE), since the reference already held those pixels.
+        let mut info = info;
+        if !h.referred.iter().any(|n| self.regions.contains_key(n)) {
+            info.op = 4; // REPLACE
+        }
+        Ok((info, bm))
+    }
+
+    /// Collect referred custom Huffman tables (type-53 segments) in referral
+    /// order, for runtime table selection in regions/dictionaries.
+    fn referred_huff_tables(&self, h: &SegmentHeader) -> Vec<&HuffTable> {
+        h.referred
+            .iter()
+            .filter_map(|n| self.huff_tables.get(n))
+            .collect()
+    }
+
+    /// Symbol dictionary segment (T.88 6.5 / 7.4.3). Supports arithmetic and
+    /// Huffman entropy coding, and refinement/aggregate (SDREFAGG) symbols.
     fn decode_symbol_dict(&self, h: &SegmentHeader, data: &[u8]) -> Result<Vec<Rc<Bitmap>>> {
         let mut r = Reader::new(data);
         let flags = r.u16()?;
         let sd_huff = flags & 1 != 0;
         let sd_refagg = flags & 2 != 0;
+        let huff_dh_sel = ((flags >> 2) & 3) as usize;
+        let huff_dw_sel = ((flags >> 4) & 3) as usize;
+        let huff_bm_sel = ((flags >> 6) & 1) as usize;
+        let huff_agg_sel = ((flags >> 7) & 1) as usize;
         let ctx_used = flags & 0x100 != 0;
         let template = ((flags >> 10) & 3) as u8;
-        if sd_huff {
-            return Err(err("Huffman-coded symbol dictionary is unsupported"));
-        }
+        let r_template = ((flags >> 12) & 1) as u8;
         if ctx_used {
             return Err(err("imported bitmap coding contexts are unsupported"));
         }
 
         let mut at = [(0i8, 0i8); 4];
-        let n_at = if template == 0 { 4 } else { 1 };
-        for slot in at.iter_mut().take(n_at) {
-            *slot = (r.i8()?, r.i8()?);
+        if !sd_huff {
+            let n_at = if template == 0 { 4 } else { 1 };
+            for slot in at.iter_mut().take(n_at) {
+                *slot = (r.i8()?, r.i8()?);
+            }
         }
-        if sd_refagg {
-            return Err(err("refinement/aggregate symbol coding is unsupported"));
+        // Refinement AT pixels (only when refinement is used and r_template 0).
+        let mut r_at = [(0i8, 0i8); 2];
+        if sd_refagg && r_template == 0 {
+            r_at[0] = (r.i8()?, r.i8()?);
+            r_at[1] = (r.i8()?, r.i8()?);
         }
 
         let num_ex = r.u32()? as usize;
@@ -943,19 +1973,117 @@ impl Decoder {
             return Err(err("too many input symbols"));
         }
 
-        let mut mq = MqDecoder::new(r.rest());
+        // Resolve the Huffman tables for SDHUFF (selectors 0/1 = standard,
+        // 3 = next custom table in referral order). DH uses B.4/B.5, DW uses
+        // B.2/B.3, BMSIZE uses B.1, AGGINST uses B.1.
+        let custom = self.referred_huff_tables(h);
+        let mut custom_iter = custom.iter();
+        let mut next_custom = || -> Result<&HuffTable> {
+            custom_iter
+                .next()
+                .copied()
+                .ok_or_else(|| err("SDHUFF references missing custom table"))
+        };
+
+        let (dh_tab, dw_tab, bmsize_tab) = if sd_huff {
+            let dh = match huff_dh_sel {
+                0 => HuffSel::Std(standard_huff_table(4)),
+                1 => HuffSel::Std(standard_huff_table(5)),
+                _ => HuffSel::Custom(next_custom()?),
+            };
+            let dw = match huff_dw_sel {
+                0 => HuffSel::Std(standard_huff_table(2)),
+                1 => HuffSel::Std(standard_huff_table(3)),
+                _ => HuffSel::Custom(next_custom()?),
+            };
+            let bmsize = match huff_bm_sel {
+                0 => HuffSel::Std(standard_huff_table(1)),
+                _ => HuffSel::Custom(next_custom()?),
+            };
+            // AGGINST table selection only matters for refinement+aggregation;
+            // consume the selector so subsequent custom tables align.
+            if sd_refagg {
+                let _agg = match huff_agg_sel {
+                    0 => HuffSel::Std(standard_huff_table(1)),
+                    _ => HuffSel::Custom(next_custom()?),
+                };
+            }
+            (Some(dh), Some(dw), Some(bmsize))
+        } else {
+            (None, None, None)
+        };
+
+        let total_input_plus_new = input.len() + num_new;
+        let sym_code_len = ceil_log2(total_input_plus_new.max(1)).max(1);
+
+        // Decode the new symbols, then the export flags, off one live stream.
+        let new_syms = if sd_huff {
+            self.decode_symbol_dict_huff(
+                r.rest(),
+                num_new,
+                num_ex,
+                &input,
+                dh_tab.as_ref().unwrap(),
+                dw_tab.as_ref().unwrap(),
+                bmsize_tab.as_ref().unwrap(),
+            )?
+        } else {
+            self.decode_symbol_dict_arith(
+                r.rest(),
+                num_new,
+                num_ex,
+                &input,
+                template,
+                at,
+                sd_refagg,
+                r_template,
+                r_at,
+                sym_code_len,
+            )?
+        };
+        Ok(new_syms)
+    }
+
+    /// Arithmetic symbol-dictionary body: decode the new symbols (with optional
+    /// refinement/aggregation) then the export flags, all off the live MQ
+    /// stream, returning the exported symbols (T.88 6.5.5–6.5.10).
+    #[allow(clippy::too_many_arguments)]
+    fn decode_symbol_dict_arith(
+        &self,
+        payload: &[u8],
+        num_new: usize,
+        num_ex: usize,
+        input: &[Rc<Bitmap>],
+        template: u8,
+        at: [(i8, i8); 4],
+        sd_refagg: bool,
+        r_template: u8,
+        r_at: [(i8, i8); 2],
+        sym_code_len: u32,
+    ) -> Result<Vec<Rc<Bitmap>>> {
+        let mut mq = MqDecoder::new(payload);
         let mut cx_gb = vec![0u8; 1 << 16];
+        let mut cx_gr = vec![0u8; 1 << 13];
         let mut iadh = vec![0u8; INT_CTX_SIZE];
         let mut iadw = vec![0u8; INT_CTX_SIZE];
         let mut iaex = vec![0u8; INT_CTX_SIZE];
+        let mut iaai = vec![0u8; INT_CTX_SIZE];
+        let mut iadt = vec![0u8; INT_CTX_SIZE];
+        let mut iafs = vec![0u8; INT_CTX_SIZE];
+        let mut iads = vec![0u8; INT_CTX_SIZE];
+        let mut iait = vec![0u8; INT_CTX_SIZE];
+        let mut iari = vec![0u8; INT_CTX_SIZE];
+        let mut iardw = vec![0u8; INT_CTX_SIZE];
+        let mut iardh = vec![0u8; INT_CTX_SIZE];
+        let mut iardx = vec![0u8; INT_CTX_SIZE];
+        let mut iardy = vec![0u8; INT_CTX_SIZE];
+        let mut iaid = vec![0u8; 1usize << (sym_code_len + 1)];
         let gp = GenericParams {
             template,
             tpgdon: false,
             at,
         };
 
-        // Height-class loop (T.88 6.5.5): IADH grows the class height, IADW
-        // deltas walk symbol widths until OOB ends the class.
         let mut new_syms: Vec<Rc<Bitmap>> = Vec::with_capacity(num_new.min(1024));
         let mut hc_height: i64 = 0;
         let mut total_area: usize = 0;
@@ -966,7 +2094,6 @@ impl Decoder {
                 return Err(err(format!("implausible symbol height {hc_height}")));
             }
             let mut sym_width: i64 = 0;
-            // OOB from IADW ends the height class.
             while let Some(dw) = decode_int(&mut mq, &mut iadw) {
                 sym_width += dw;
                 if sym_width <= 0 || sym_width > MAX_DIMENSION as i64 {
@@ -979,19 +2106,79 @@ impl Decoder {
                 if total_area > MAX_BITMAP_PIXELS {
                     return Err(err("symbol dictionary exceeds the pixel limit"));
                 }
-                let bm = decode_generic(
-                    &mut mq,
-                    &mut cx_gb,
-                    sym_width as usize,
-                    hc_height as usize,
-                    &gp,
-                )?;
+                let bm = if sd_refagg {
+                    // REFAGG: IAAI counts the aggregate instances (T.88 6.5.8.2).
+                    let n_inst = decode_int(&mut mq, &mut iaai)
+                        .ok_or_else(|| err("unexpected OOB in IAAI"))?;
+                    let all: Vec<Rc<Bitmap>> =
+                        input.iter().chain(new_syms.iter()).cloned().collect();
+                    if n_inst == 1 {
+                        // Single-instance refinement of an existing symbol.
+                        let id = decode_iaid(&mut mq, &mut iaid, sym_code_len);
+                        let rdx = decode_int(&mut mq, &mut iardx)
+                            .ok_or_else(|| err("unexpected OOB in IARDX"))?;
+                        let rdy = decode_int(&mut mq, &mut iardy)
+                            .ok_or_else(|| err("unexpected OOB in IARDY"))?;
+                        let refr = all.get(id).ok_or_else(|| {
+                            err(format!("refinement symbol id {id} out of range"))
+                        })?;
+                        decode_refinement(
+                            &mut mq,
+                            &mut cx_gr,
+                            sym_width as usize,
+                            hc_height as usize,
+                            refr,
+                            &RefinementParams {
+                                template: r_template,
+                                tpgron: false,
+                                at: r_at,
+                                dx: rdx as i32,
+                                dy: rdy as i32,
+                            },
+                        )?
+                    } else {
+                        // Aggregate: a text region placing n_inst instances.
+                        if n_inst <= 0 || n_inst as usize > MAX_INSTANCES {
+                            return Err(err("implausible aggregate instance count"));
+                        }
+                        let mut ctx = TextArithCtx {
+                            iadt: &mut iadt,
+                            iafs: &mut iafs,
+                            iads: &mut iads,
+                            iait: &mut iait,
+                            iari: &mut iari,
+                            iardw: &mut iardw,
+                            iardh: &mut iardh,
+                            iardx: &mut iardx,
+                            iardy: &mut iardy,
+                            iaid: &mut iaid,
+                            cx_gr: &mut cx_gr,
+                        };
+                        decode_text_region_arith(
+                            &mut mq,
+                            sym_width as usize,
+                            hc_height as usize,
+                            &all,
+                            n_inst as usize,
+                            sym_code_len,
+                            &TextRegionGeom::aggregate(r_template, r_at),
+                            &mut ctx,
+                        )?
+                    }
+                } else {
+                    decode_generic(
+                        &mut mq,
+                        &mut cx_gb,
+                        sym_width as usize,
+                        hc_height as usize,
+                        &gp,
+                    )?
+                };
                 new_syms.push(Rc::new(bm));
             }
         }
 
-        // Export flags (T.88 6.5.10): alternating skip/export run lengths over
-        // the concatenation of input and new symbols.
+        // Export flags (T.88 6.5.10): IAEX run lengths over input++new.
         let total = input.len() + new_syms.len();
         let mut exported: Vec<Rc<Bitmap>> = Vec::with_capacity(num_ex.min(1024));
         let mut idx = 0usize;
@@ -1023,14 +2210,146 @@ impl Decoder {
         Ok(exported)
     }
 
-    /// Text region segment (T.88 6.4 / 7.4.4), arithmetic coding only.
+    /// Huffman symbol-dictionary body (T.88 6.5.8.2.3 / 6.5.9). Height-class
+    /// collective bitmaps are MMR-coded (size 0) or fixed at BMSIZE bytes, then
+    /// sliced per symbol width. Export flags use the table-B.1 run lengths.
+    #[allow(clippy::too_many_arguments)]
+    fn decode_symbol_dict_huff(
+        &self,
+        payload: &[u8],
+        num_new: usize,
+        num_ex: usize,
+        input: &[Rc<Bitmap>],
+        dh_tab: &HuffSel,
+        dw_tab: &HuffSel,
+        bmsize_tab: &HuffSel,
+    ) -> Result<Vec<Rc<Bitmap>>> {
+        let mut br = BitReader::new(payload);
+        let mut new_syms: Vec<Rc<Bitmap>> = Vec::with_capacity(num_new.min(1024));
+        let mut hc_height: i64 = 0;
+        let mut total_area: usize = 0;
+        while new_syms.len() < num_new {
+            let dh = dh_tab
+                .table()
+                .decode(&mut br)
+                .ok_or_else(|| err("unexpected OOB in Huffman DH"))?;
+            hc_height += dh;
+            if hc_height <= 0 || hc_height > MAX_DIMENSION as i64 {
+                return Err(err(format!("implausible symbol height {hc_height}")));
+            }
+            let class_start = new_syms.len();
+            let mut widths: Vec<usize> = Vec::new();
+            let mut sym_width: i64 = 0;
+            let mut totwidth: i64 = 0;
+            // OOB from DW ends the height class.
+            while let Some(dw) = dw_tab.table().decode(&mut br) {
+                sym_width += dw;
+                if sym_width <= 0 || sym_width > MAX_DIMENSION as i64 {
+                    return Err(err(format!("implausible symbol width {sym_width}")));
+                }
+                if class_start + widths.len() >= num_new {
+                    return Err(err("more symbols coded than declared"));
+                }
+                totwidth += sym_width;
+                widths.push(sym_width as usize);
+                total_area = total_area.saturating_add((sym_width * hc_height) as usize);
+                if total_area > MAX_BITMAP_PIXELS {
+                    return Err(err("symbol dictionary exceeds the pixel limit"));
+                }
+            }
+            if totwidth <= 0 {
+                continue;
+            }
+            // BMSIZE: 0 → MMR collective bitmap consuming the remainder of the
+            // height class; >0 → exactly that many bytes (T.88 6.5.9).
+            let bmsize = bmsize_tab
+                .table()
+                .decode(&mut br)
+                .ok_or_else(|| err("unexpected OOB in Huffman BMSIZE"))?;
+            br.byte_align();
+            let cw = totwidth as usize;
+            let ch = hc_height as usize;
+            let start = br.byte_pos();
+            let mmr_data = if bmsize == 0 {
+                &payload[start.min(payload.len())..]
+            } else {
+                let end = start.saturating_add(bmsize as usize).min(payload.len());
+                &payload[start.min(payload.len())..end]
+            };
+            let params = crate::ccitt::CcittParams {
+                k: -1,
+                columns: cw.max(1),
+                rows: ch,
+                black_is_1: true,
+                byte_align: false,
+            };
+            let packed = crate::ccitt::decode(mmr_data, &params)?;
+            let collective = unpack_rows(&packed, cw, ch)?;
+            let consumed = if bmsize == 0 {
+                payload.len().saturating_sub(start)
+            } else {
+                bmsize as usize
+            };
+            br.pos = (start + consumed) * 8;
+            let mut x0 = 0usize;
+            for &w in &widths {
+                let mut sym = Bitmap::new(w, ch, 0)?;
+                for yy in 0..ch {
+                    for xx in 0..w {
+                        if collective.get((x0 + xx) as i64, yy as i64) != 0 {
+                            sym.set(xx, yy, 1);
+                        }
+                    }
+                }
+                new_syms.push(Rc::new(sym));
+                x0 += w;
+            }
+        }
+
+        // Export flags via table B.1 run lengths (T.88 6.5.10).
+        let ex_tab = standard_huff_table(1);
+        let total = input.len() + new_syms.len();
+        let mut exported: Vec<Rc<Bitmap>> = Vec::with_capacity(num_ex.min(1024));
+        let mut idx = 0usize;
+        let mut exporting = false;
+        while idx < total {
+            let run = ex_tab
+                .decode(&mut br)
+                .ok_or_else(|| err("unexpected OOB in Huffman EXFLAGS"))?;
+            if run < 0 || idx as i64 + run > total as i64 {
+                return Err(err("invalid symbol export run length"));
+            }
+            if exporting {
+                for i in idx..idx + run as usize {
+                    exported.push(if i < input.len() {
+                        Rc::clone(&input[i])
+                    } else {
+                        Rc::clone(&new_syms[i - input.len()])
+                    });
+                }
+            }
+            idx += run as usize;
+            exporting = !exporting;
+        }
+        if exported.len() != num_ex {
+            warn!(
+                "JBIG2Decode: Huffman symbol dictionary exported {} symbols, declared {num_ex}",
+                exported.len()
+            );
+        }
+        Ok(exported)
+    }
+
+    /// Text region segment (T.88 6.4 / 7.4.4): arithmetic or Huffman coding,
+    /// with optional per-instance symbol refinement.
     fn decode_text_region(&self, h: &SegmentHeader, data: &[u8]) -> Result<(RegionInfo, Bitmap)> {
         let mut r = Reader::new(data);
         let info = parse_region_info(&mut r)?;
         let flags = r.u16()?;
         let sb_huff = flags & 1 != 0;
         let sb_refine = flags & 2 != 0;
-        let strips = 1i64 << ((flags >> 2) & 3);
+        let log_strips = ((flags >> 2) & 3) as u32;
+        let strips = 1i64 << log_strips;
         let ref_corner = ((flags >> 4) & 3) as u8; // 0=BL 1=TL 2=BR 3=TR
         let transposed = flags & 0x40 != 0;
         let comb_op = ((flags >> 7) & 3) as u8;
@@ -1039,13 +2358,15 @@ impl Decoder {
         if ds_offset > 15 {
             ds_offset -= 32;
         }
-        let rtemplate = (flags >> 15) & 1;
+        let r_template = ((flags >> 15) & 1) as u8;
 
-        if sb_huff {
-            return Err(err("Huffman-coded text region is unsupported"));
-        }
-        if sb_refine && rtemplate == 0 {
-            r.take(4)?; // refinement AT pixels (refinement itself unsupported)
+        // Huffman flags (T.88 7.4.4.1.2): per-field table selectors.
+        let huff_flags = if sb_huff { r.u16()? } else { 0 };
+
+        let mut r_at = [(0i8, 0i8); 2];
+        if sb_refine && r_template == 0 {
+            r_at[0] = (r.i8()?, r.i8()?);
+            r_at[1] = (r.i8()?, r.i8()?);
         }
         let num_instances = r.u32()? as usize;
         if num_instances > MAX_INSTANCES {
@@ -1073,74 +2394,494 @@ impl Decoder {
         // T.88 (as amended) and shipping encoders use max(1, ceil(log2 n)).
         let sym_code_len = ceil_log2(symbols.len()).max(1);
 
+        let geom = TextRegionGeom {
+            log_strips,
+            strips,
+            ref_corner,
+            transposed,
+            comb_op,
+            def_pixel,
+            ds_offset,
+            sb_refine,
+            r_template,
+            r_at,
+        };
+
+        if sb_huff {
+            return self.decode_text_region_huff(
+                r.rest(),
+                &info,
+                &geom,
+                huff_flags,
+                h,
+                &symbols,
+                num_instances,
+            );
+        }
+
         let mut mq = MqDecoder::new(r.rest());
         let mut iadt = vec![0u8; INT_CTX_SIZE];
         let mut iafs = vec![0u8; INT_CTX_SIZE];
         let mut iads = vec![0u8; INT_CTX_SIZE];
         let mut iait = vec![0u8; INT_CTX_SIZE];
         let mut iari = vec![0u8; INT_CTX_SIZE];
+        let mut iardw = vec![0u8; INT_CTX_SIZE];
+        let mut iardh = vec![0u8; INT_CTX_SIZE];
+        let mut iardx = vec![0u8; INT_CTX_SIZE];
+        let mut iardy = vec![0u8; INT_CTX_SIZE];
         let mut iaid = vec![0u8; 1usize << (sym_code_len + 1)];
+        let mut cx_gr = vec![0u8; 1 << 13];
+        let mut ctx = TextArithCtx {
+            iadt: &mut iadt,
+            iafs: &mut iafs,
+            iads: &mut iads,
+            iait: &mut iait,
+            iari: &mut iari,
+            iardw: &mut iardw,
+            iardh: &mut iardh,
+            iardx: &mut iardx,
+            iardy: &mut iardy,
+            iaid: &mut iaid,
+            cx_gr: &mut cx_gr,
+        };
+        let bm = decode_text_region_arith(
+            &mut mq,
+            info.width,
+            info.height,
+            &symbols,
+            num_instances,
+            sym_code_len,
+            &geom,
+            &mut ctx,
+        )?;
+        Ok((info, bm))
+    }
 
-        let mut bm = Bitmap::new(info.width, info.height, def_pixel)?;
+    /// Huffman text-region body (T.88 6.4.5 with Huffman entropy). Resolves the
+    /// FS/DS/DT/RDW/RDH/RDX/RDY tables and the runtime symbol-ID table, then
+    /// runs the placement loop with optional refinement.
+    #[allow(clippy::too_many_arguments)]
+    fn decode_text_region_huff(
+        &self,
+        payload: &[u8],
+        info: &RegionInfo,
+        geom: &TextRegionGeom,
+        huff_flags: u16,
+        h: &SegmentHeader,
+        symbols: &[Rc<Bitmap>],
+        num_instances: usize,
+    ) -> Result<(RegionInfo, Bitmap)> {
+        let custom = self.referred_huff_tables(h);
+        let mut custom_iter = custom.iter();
+        let mut next_custom = || -> Result<&HuffTable> {
+            custom_iter
+                .next()
+                .copied()
+                .ok_or_else(|| err("SBHUFF references missing custom table"))
+        };
 
-        // T.88 6.4.5: STRIPT starts at minus the first IADT value (in strips).
-        let mut stript =
-            -decode_int(&mut mq, &mut iadt).ok_or_else(|| err("unexpected OOB in IADT"))? * strips;
+        // Field-table selectors (T.88 7.4.4.1.2 Table 32).
+        let fs_sel = huff_flags & 3;
+        let ds_sel = (huff_flags >> 2) & 3;
+        let dt_sel = (huff_flags >> 4) & 3;
+        let rdw_sel = (huff_flags >> 6) & 3;
+        let rdh_sel = (huff_flags >> 8) & 3;
+        let rdx_sel = (huff_flags >> 10) & 3;
+        let rdy_sel = (huff_flags >> 12) & 3;
+        let rsize_sel = (huff_flags >> 14) & 1;
+
+        let fs_tab = match fs_sel {
+            0 => HuffSel::Std(standard_huff_table(6)),
+            1 => HuffSel::Std(standard_huff_table(7)),
+            _ => HuffSel::Custom(next_custom()?),
+        };
+        let ds_tab = match ds_sel {
+            0 => HuffSel::Std(standard_huff_table(8)),
+            1 => HuffSel::Std(standard_huff_table(9)),
+            2 => HuffSel::Std(standard_huff_table(10)),
+            _ => HuffSel::Custom(next_custom()?),
+        };
+        let dt_tab = match dt_sel {
+            0 => HuffSel::Std(standard_huff_table(11)),
+            1 => HuffSel::Std(standard_huff_table(12)),
+            2 => HuffSel::Std(standard_huff_table(13)),
+            _ => HuffSel::Custom(next_custom()?),
+        };
+        let rdw_tab = match rdw_sel {
+            0 => HuffSel::Std(standard_huff_table(14)),
+            1 => HuffSel::Std(standard_huff_table(15)),
+            _ => HuffSel::Custom(next_custom()?),
+        };
+        let rdh_tab = match rdh_sel {
+            0 => HuffSel::Std(standard_huff_table(14)),
+            1 => HuffSel::Std(standard_huff_table(15)),
+            _ => HuffSel::Custom(next_custom()?),
+        };
+        let rdx_tab = match rdx_sel {
+            0 => HuffSel::Std(standard_huff_table(14)),
+            1 => HuffSel::Std(standard_huff_table(15)),
+            _ => HuffSel::Custom(next_custom()?),
+        };
+        let rdy_tab = match rdy_sel {
+            0 => HuffSel::Std(standard_huff_table(14)),
+            1 => HuffSel::Std(standard_huff_table(15)),
+            _ => HuffSel::Custom(next_custom()?),
+        };
+        let rsize_tab = match rsize_sel {
+            0 => HuffSel::Std(standard_huff_table(1)),
+            _ => HuffSel::Custom(next_custom()?),
+        };
+
+        let mut br = BitReader::new(payload);
+        // Symbol-ID Huffman table (T.88 7.4.4.1.4): 35 run-code lengths, then
+        // the per-symbol code lengths decoded with those run codes.
+        let id_tab = read_symbol_id_huff_table(&mut br, symbols.len())?;
+
+        let mut bm = Bitmap::new(info.width, info.height, geom.def_pixel)?;
+        let strips = geom.strips;
+
+        let mut stript = -dt_tab
+            .table()
+            .decode(&mut br)
+            .ok_or_else(|| err("unexpected OOB in Huffman DT"))?
+            * strips;
         let mut firsts: i64 = 0;
         let mut inst = 0usize;
 
         'instances: while inst < num_instances {
-            let dt = decode_int(&mut mq, &mut iadt).ok_or_else(|| err("unexpected OOB in IADT"))?;
+            let dt = dt_tab
+                .table()
+                .decode(&mut br)
+                .ok_or_else(|| err("unexpected OOB in Huffman DT"))?;
             stript += dt * strips;
-            let dfs =
-                decode_int(&mut mq, &mut iafs).ok_or_else(|| err("unexpected OOB in IAFS"))?;
+            let dfs = fs_tab
+                .table()
+                .decode(&mut br)
+                .ok_or_else(|| err("unexpected OOB in Huffman FS"))?;
             firsts += dfs;
             let mut curs = firsts;
             let mut first = true;
             loop {
                 if !first {
-                    // IADS: OOB terminates the strip.
-                    let Some(ids) = decode_int(&mut mq, &mut iads) else {
-                        break;
+                    let Some(ids) = ds_tab.table().decode(&mut br) else {
+                        break; // OOB ends the strip
                     };
-                    curs += ids + ds_offset;
+                    curs += ids + geom.ds_offset;
                 }
                 first = false;
                 if inst >= num_instances {
                     break 'instances;
                 }
-
                 let curt = if strips == 1 {
                     0
                 } else {
-                    decode_int(&mut mq, &mut iait).ok_or_else(|| err("unexpected OOB in IAIT"))?
+                    br.read_bits(geom.log_strips) as i64
                 };
                 let t = stript + curt;
-                let id = decode_iaid(&mut mq, &mut iaid, sym_code_len);
-                if sb_refine {
-                    let ri = decode_int(&mut mq, &mut iari)
-                        .ok_or_else(|| err("unexpected OOB in IARI"))?;
+                let id = id_tab
+                    .decode(&mut br)
+                    .ok_or_else(|| err("unexpected OOB in symbol ID"))?
+                    as usize;
+                let sym = symbols
+                    .get(id)
+                    .ok_or_else(|| err(format!("symbol id {id} out of range")))?
+                    .clone();
+
+                let refined = if geom.sb_refine {
+                    let ri = br.read_bit();
                     if ri != 0 {
-                        return Err(err("text region symbol refinement is unsupported"));
+                        let rdw = rdw_tab
+                            .table()
+                            .decode(&mut br)
+                            .ok_or_else(|| err("unexpected OOB in Huffman RDW"))?;
+                        let rdh = rdh_tab
+                            .table()
+                            .decode(&mut br)
+                            .ok_or_else(|| err("unexpected OOB in Huffman RDH"))?;
+                        let rdx = rdx_tab
+                            .table()
+                            .decode(&mut br)
+                            .ok_or_else(|| err("unexpected OOB in Huffman RDX"))?;
+                        let rdy = rdy_tab
+                            .table()
+                            .decode(&mut br)
+                            .ok_or_else(|| err("unexpected OOB in Huffman RDY"))?;
+                        let _rsize = rsize_tab
+                            .table()
+                            .decode(&mut br)
+                            .ok_or_else(|| err("unexpected OOB in Huffman RSIZE"))?;
+                        br.byte_align();
+                        let nw = sym.width as i64 + rdw;
+                        let nh = sym.height as i64 + rdh;
+                        if nw <= 0
+                            || nh <= 0
+                            || nw > MAX_DIMENSION as i64
+                            || nh > MAX_DIMENSION as i64
+                        {
+                            return Err(err("implausible refined symbol size"));
+                        }
+                        let dx = (rdw >> 1) + rdx;
+                        let dy = (rdh >> 1) + rdy;
+                        let mut mq = MqDecoder::new(&payload[br.byte_pos().min(payload.len())..]);
+                        let mut cx = vec![0u8; 1 << 13];
+                        let refined = decode_refinement(
+                            &mut mq,
+                            &mut cx,
+                            nw as usize,
+                            nh as usize,
+                            &sym,
+                            &RefinementParams {
+                                template: geom.r_template,
+                                tpgron: false,
+                                at: geom.r_at,
+                                dx: dx as i32,
+                                dy: dy as i32,
+                            },
+                        )?;
+                        // Advance past the refinement MQ data using RSIZE.
+                        br.pos = (br.byte_pos() + _rsize.max(0) as usize) * 8;
+                        Some(refined)
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                };
+
+                curs += place_instance(&mut bm, &sym, refined, t, curs, geom);
+                inst += 1;
+            }
+        }
+        Ok((info.clone(), bm))
+    }
+
+    /// Pattern dictionary segment (T.88 6.7 / 7.4.4). Decodes one wide generic
+    /// region holding HDMAX+1 patterns side by side and slices it into the
+    /// individual pattern bitmaps.
+    fn decode_pattern_dict(&self, data: &[u8]) -> Result<PatternDict> {
+        let mut r = Reader::new(data);
+        let flags = r.u8()?;
+        let mmr = flags & 1 != 0;
+        let template = (flags >> 1) & 3;
+        let hdpw = r.u8()? as usize;
+        let hdph = r.u8()? as usize;
+        let gray_max = r.u32()? as usize; // HDMAX (largest pattern index)
+        if hdpw == 0 || hdph == 0 || hdpw > MAX_DIMENSION || hdph > MAX_DIMENSION {
+            return Err(err(format!("implausible pattern size {hdpw}x{hdph}")));
+        }
+        let n_patterns = gray_max
+            .checked_add(1)
+            .filter(|&n| n <= MAX_SYMBOLS)
+            .ok_or_else(|| err("pattern dictionary declares too many patterns"))?;
+        let collective_w = hdpw
+            .checked_mul(n_patterns)
+            .filter(|&w| w <= MAX_DIMENSION)
+            .ok_or_else(|| err("pattern dictionary collective bitmap too wide"))?;
+        if collective_w
+            .checked_mul(hdph)
+            .map(|p| p > MAX_BITMAP_PIXELS)
+            .unwrap_or(true)
+        {
+            return Err(err("pattern dictionary exceeds the pixel limit"));
+        }
+
+        // Decode the collective bitmap. The AT pixels are fixed (T.88 6.7.5):
+        // A1 = (-HDPW, 0), A2 = (-3, -1), A3 = (2, -2), A4 = (-2, -2).
+        let collective = if mmr {
+            let params = crate::ccitt::CcittParams {
+                k: -1,
+                columns: collective_w.max(1),
+                rows: hdph,
+                black_is_1: true,
+                byte_align: false,
+            };
+            let packed = crate::ccitt::decode(r.rest(), &params)?;
+            unpack_rows(&packed, collective_w, hdph)?
+        } else {
+            let at = [
+                (-(hdpw as i64).min(127) as i8, 0i8),
+                (-3, -1),
+                (2, -2),
+                (-2, -2),
+            ];
+            let mut mq = MqDecoder::new(r.rest());
+            let mut cx = vec![0u8; 1 << 16];
+            decode_generic(
+                &mut mq,
+                &mut cx,
+                collective_w,
+                hdph,
+                &GenericParams {
+                    template,
+                    tpgdon: false,
+                    at,
+                },
+            )?
+        };
+
+        // Slice into HDMAX+1 patterns (T.88 6.7.5 step 4).
+        let mut patterns = Vec::with_capacity(n_patterns);
+        for idx in 0..n_patterns {
+            let x0 = idx * hdpw;
+            let mut p = Bitmap::new(hdpw, hdph, 0)?;
+            for yy in 0..hdph {
+                for xx in 0..hdpw {
+                    if collective.get((x0 + xx) as i64, yy as i64) != 0 {
+                        p.set(xx, yy, 1);
                     }
                 }
+            }
+            patterns.push(Rc::new(p));
+        }
+        Ok(PatternDict { patterns })
+    }
 
-                let Some(sym) = symbols.get(id) else {
-                    return Err(err(format!("symbol id {id} out of range")));
-                };
-                let (w, hh) = (sym.width as i64, sym.height as i64);
-                if !transposed {
-                    // S is x; TOP corners (1, 3) anchor at T, BOTTOM shift up.
-                    let y0 = t - if ref_corner & 1 == 0 { hh - 1 } else { 0 };
-                    draw_symbol(&mut bm, sym, curs, y0, comb_op);
-                    curs += w - 1;
-                } else {
-                    // S is y; RIGHT corners (2, 3) shift left of T.
-                    let x0 = t - if ref_corner & 2 != 0 { w - 1 } else { 0 };
-                    draw_symbol(&mut bm, sym, x0, curs, comb_op);
-                    curs += hh - 1;
+    /// Halftone region segment (T.88 6.6 / 7.4.5). Decodes the grayscale image
+    /// (HBPP Gray-coded bitplanes) and tiles the referred pattern dictionary
+    /// across the HGW×HGH grid.
+    fn decode_halftone_region(
+        &self,
+        h: &SegmentHeader,
+        data: &[u8],
+    ) -> Result<(RegionInfo, Bitmap)> {
+        let mut r = Reader::new(data);
+        let info = parse_region_info(&mut r)?;
+        let flags = r.u8()?;
+        let mmr = flags & 1 != 0;
+        let template = (flags >> 1) & 3;
+        let enable_skip = flags & 8 != 0;
+        let comb_op = (flags >> 4) & 7;
+        let def_pixel = (flags >> 7) & 1;
+        let hgw = r.u32()? as usize;
+        let hgh = r.u32()? as usize;
+        let hgx = r.u32()? as i32;
+        let hgy = r.u32()? as i32;
+        let hrx = r.u16()? as i32;
+        let hry = r.u16()? as i32;
+
+        if hgw == 0 || hgh == 0 || hgw > MAX_DIMENSION || hgh > MAX_DIMENSION {
+            return Err(err(format!("implausible halftone grid {hgw}x{hgh}")));
+        }
+        let grid_cells = hgw
+            .checked_mul(hgh)
+            .filter(|&n| n <= MAX_BITMAP_PIXELS)
+            .ok_or_else(|| err("halftone grid exceeds the pixel limit"))?;
+
+        // Find the referred pattern dictionary.
+        let pd = h
+            .referred
+            .iter()
+            .find_map(|n| self.pattern_dicts.get(n))
+            .ok_or_else(|| err("halftone region refers to no pattern dictionary"))?
+            .as_ref()
+            .ok_or_else(|| err("referred pattern dictionary failed to decode"))?;
+        if pd.patterns.is_empty() {
+            return Err(err("empty pattern dictionary"));
+        }
+        let pat_w = pd.patterns[0].width;
+        let pat_h = pd.patterns[0].height;
+        // HBPP = ceil(log2(number of patterns)) (T.88 C.5).
+        let hbpp = ceil_log2(pd.patterns.len()).max(1) as usize;
+        if hbpp > 31 {
+            return Err(err("implausible halftone bit depth"));
+        }
+
+        let mut bm = Bitmap::new(info.width, info.height, def_pixel)?;
+
+        // Optional skip bitmap (T.88 6.6.5.1): a cell is skipped when its
+        // pattern would fall entirely outside the region.
+        let skip = if enable_skip {
+            let mut s = Bitmap::new(hgw, hgh, 0)?;
+            for m in 0..hgh as i32 {
+                for n in 0..hgw as i32 {
+                    let x = (hgx + m * hry + n * hrx) >> 8;
+                    let y = (hgy + m * hrx - n * hry) >> 8;
+                    if x + (pat_w as i32) <= 0
+                        || x >= info.width as i32
+                        || y + (pat_h as i32) <= 0
+                        || y >= info.height as i32
+                    {
+                        s.set(n as usize, m as usize, 1);
+                    }
                 }
-                inst += 1;
+            }
+            Some(s)
+        } else {
+            None
+        };
+
+        // Decode the grayscale image: HBPP bitplanes, MSB first, Gray-coded
+        // (T.88 Annex C.5). Each plane is a generic region of size HGW×HGH.
+        let mut gray = vec![0u32; grid_cells];
+        // The grayscale generic regions use template AT pixels per T.88 C.2:
+        // A1 = (template<=1 ? 3 : 2, -1), then (-3,-1), (2,-2), (-2,-2).
+        let at = [
+            (if template <= 1 { 3 } else { 2 }, -1),
+            (-3, -1),
+            (2, -2),
+            (-2, -2),
+        ];
+        let mut mq = if mmr {
+            None
+        } else {
+            Some(MqDecoder::new(r.rest()))
+        };
+        let mut cx = if mmr { Vec::new() } else { vec![0u8; 1 << 16] };
+        // MMR planes are concatenated; the CCITT decoder consumes one full
+        // image per call but does not report bytes consumed, so multi-plane
+        // MMR halftones can only be tracked for the common single-plane case.
+        let mmr_data = r.rest();
+        // `bit[j+1]` accumulator for the Gray decode, per cell.
+        let mut prev_bit = vec![0u8; grid_cells];
+        for j in (0..hbpp).rev() {
+            let plane = if let Some(mqd) = mq.as_mut() {
+                decode_generic(
+                    mqd,
+                    &mut cx,
+                    hgw,
+                    hgh,
+                    &GenericParams {
+                        template,
+                        tpgdon: false,
+                        at,
+                    },
+                )?
+            } else {
+                let params = crate::ccitt::CcittParams {
+                    k: -1,
+                    columns: hgw.max(1),
+                    rows: hgh,
+                    black_is_1: true,
+                    byte_align: false,
+                };
+                let packed = crate::ccitt::decode(mmr_data, &params)?;
+                unpack_rows(&packed, hgw, hgh)?
+            };
+            // Gray-code combine: the j-th gray bit is plane XOR the (j+1)-th bit.
+            for i in 0..grid_cells {
+                let py = (i / hgw) as i64;
+                let px = (i % hgw) as i64;
+                let bit = plane.get(px, py) ^ prev_bit[i];
+                gray[i] |= (bit as u32) << j;
+                prev_bit[i] = bit;
+            }
+        }
+
+        // Place patterns on the grid (T.88 6.6.5.2).
+        let n_pat = pd.patterns.len();
+        for m in 0..hgh {
+            for n in 0..hgw {
+                if let Some(s) = &skip {
+                    if s.get(n as i64, m as i64) != 0 {
+                        continue;
+                    }
+                }
+                let gi = gray[m * hgw + n] as usize;
+                let idx = gi.min(n_pat - 1);
+                let pat = &pd.patterns[idx];
+                let x = (hgx + (m as i32) * hry + (n as i32) * hrx) >> 8;
+                let y = (hgy + (m as i32) * hrx - (n as i32) * hry) >> 8;
+                place_pattern(&mut bm, pat, x, y, comb_op);
             }
         }
         Ok((info, bm))
@@ -1415,6 +3156,121 @@ mod tests {
                 enc.encode(cx, ctx, bm.get(x as i64, y as i64));
             }
         }
+    }
+
+    /// Encoder mirror of [`decode_refinement`]: encodes `bm` as a refinement of
+    /// `refr`. With TPGRON off (used by the tests) the loop matches the decoder
+    /// pixel-for-pixel.
+    fn encode_refinement(
+        enc: &mut MqEncoder,
+        cx: &mut [u8],
+        bm: &Bitmap,
+        refr: &Bitmap,
+        p: &RefinementParams,
+    ) {
+        assert!(!p.tpgron, "test encoder only covers TPGRON off");
+        for y in 0..bm.height as i64 {
+            for x in 0..bm.width as i64 {
+                let rx = x - p.dx as i64;
+                let ry = y - p.dy as i64;
+                let ctx = refine_context(p.template, bm, refr, x, y, rx, ry, &p.at);
+                enc.encode(cx, ctx, bm.get(x, y));
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Test-only Huffman bit writer and table encoder.
+    // -----------------------------------------------------------------------
+
+    /// MSB-first bit writer, the encode mirror of [`BitReader`].
+    struct BitWriter {
+        out: Vec<u8>,
+        cur: u8,
+        nbits: u32,
+    }
+
+    impl BitWriter {
+        fn new() -> Self {
+            Self {
+                out: Vec::new(),
+                cur: 0,
+                nbits: 0,
+            }
+        }
+        fn write_bit(&mut self, bit: u32) {
+            self.cur = (self.cur << 1) | (bit & 1) as u8;
+            self.nbits += 1;
+            if self.nbits == 8 {
+                self.out.push(self.cur);
+                self.cur = 0;
+                self.nbits = 0;
+            }
+        }
+        fn write_bits(&mut self, v: u32, n: u32) {
+            for k in (0..n).rev() {
+                self.write_bit((v >> k) & 1);
+            }
+        }
+        fn byte_align(&mut self) {
+            if self.nbits > 0 {
+                self.cur <<= 8 - self.nbits;
+                self.out.push(self.cur);
+                self.cur = 0;
+                self.nbits = 0;
+            }
+        }
+        fn finish(mut self) -> Vec<u8> {
+            self.byte_align();
+            self.out
+        }
+    }
+
+    /// Encode `value` (or OOB) with a Huffman table by finding the matching
+    /// line and emitting its prefix code plus the range magnitude.
+    fn huff_encode(bw: &mut BitWriter, tab: &HuffTable, value: Option<i64>) {
+        for (i, l) in tab.lines.iter().enumerate() {
+            let matches = match value {
+                None => l.is_oob,
+                Some(v) => {
+                    if l.is_oob {
+                        false
+                    } else if l.range_len == 32 {
+                        if l.is_lower {
+                            v <= l.range_low as i64
+                        } else {
+                            v >= l.range_low as i64
+                        }
+                    } else {
+                        let span = 1i64 << l.range_len;
+                        if l.is_lower {
+                            v <= l.range_low as i64 && v > l.range_low as i64 - span
+                        } else {
+                            v >= l.range_low as i64 && v < l.range_low as i64 + span
+                        }
+                    }
+                }
+            };
+            if matches && l.prefix_len > 0 {
+                bw.write_bits(tab.codes[i], l.prefix_len as u32);
+                if l.is_oob {
+                    return;
+                }
+                let mag = if l.is_lower {
+                    l.range_low as i64 - value.unwrap()
+                } else {
+                    value.unwrap() - l.range_low as i64
+                };
+                let bits = if l.range_len == 32 {
+                    32
+                } else {
+                    l.range_len as u32
+                };
+                bw.write_bits(mag as u32, bits);
+                return;
+            }
+        }
+        panic!("no Huffman line matches {value:?}");
     }
 
     // -----------------------------------------------------------------------
@@ -2053,5 +3909,522 @@ mod tests {
         stream.extend_from_slice(&segment(1, 38, &[], 1, &payload));
         let out = decode(&stream, &Jbig2Params { globals: None }).unwrap();
         assert_eq!(out, packed_from(&["........", "......##", "........"]));
+    }
+
+    // -----------------------------------------------------------------------
+    // Generic refinement region (step 1).
+    // -----------------------------------------------------------------------
+
+    /// Nominal refinement AT pixels per GRTEMPLATE (T.88 6.3.5.3): A1 = (-1,-1)
+    /// in the current bitmap, A2 = (-1,-1) in the reference.
+    fn nominal_refine_at() -> [(i8, i8); 2] {
+        [(-1, -1), (-1, -1)]
+    }
+
+    #[test]
+    fn refinement_round_trip_both_templates() {
+        // Reference is a coarse blob; the refined bitmap tweaks a few pixels.
+        let refr = bitmap_from(&[
+            "........", ".#####..", ".#####..", ".#####..", ".#####..", "........",
+        ]);
+        let target = bitmap_from(&[
+            "..####..", ".#...#..", ".#...#..", ".#...#..", ".#####..", "...#....",
+        ]);
+        for template in 0..2u8 {
+            let p = RefinementParams {
+                template,
+                tpgron: false,
+                at: nominal_refine_at(),
+                dx: 0,
+                dy: 0,
+            };
+            let mut enc = MqEncoder::new();
+            let mut cx = vec![0u8; 1 << 13];
+            encode_refinement(&mut enc, &mut cx, &target, &refr, &p);
+            let data = enc.finish();
+            let mut dec = MqDecoder::new(&data);
+            let mut cx = vec![0u8; 1 << 13];
+            let out = decode_refinement(&mut dec, &mut cx, target.width, target.height, &refr, &p)
+                .unwrap();
+            assert_eq!(out.data, target.data, "template {template}");
+        }
+    }
+
+    #[test]
+    fn refinement_round_trip_with_offset() {
+        // A non-zero reference offset (dx, dy) exercises the rx = x - dx path
+        // shared by symbol-dict and text-region refinement.
+        let refr = bitmap_from(&[
+            "........", "..####..", "..#..#..", "..#..#..", "..####..", "........",
+        ]);
+        let target = bitmap_from(&[
+            "........", "..####..", "..#.##..", "..#..#..", "..####..", "........",
+        ]);
+        for (dx, dy) in [(1, 0), (-1, 1), (0, -1)] {
+            for template in 0..2u8 {
+                let p = RefinementParams {
+                    template,
+                    tpgron: false,
+                    at: nominal_refine_at(),
+                    dx,
+                    dy,
+                };
+                let mut enc = MqEncoder::new();
+                let mut cx = vec![0u8; 1 << 13];
+                encode_refinement(&mut enc, &mut cx, &target, &refr, &p);
+                let data = enc.finish();
+                let mut dec = MqDecoder::new(&data);
+                let mut cx = vec![0u8; 1 << 13];
+                let out =
+                    decode_refinement(&mut dec, &mut cx, target.width, target.height, &refr, &p)
+                        .unwrap();
+                assert_eq!(
+                    out.data, target.data,
+                    "template {template} offset ({dx},{dy})"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn refinement_identity_reproduces_reference() {
+        // Refining a bitmap against itself must reproduce it exactly.
+        let refr = test_pattern();
+        let p = RefinementParams {
+            template: 1,
+            tpgron: false,
+            at: nominal_refine_at(),
+            dx: 0,
+            dy: 0,
+        };
+        let mut enc = MqEncoder::new();
+        let mut cx = vec![0u8; 1 << 13];
+        encode_refinement(&mut enc, &mut cx, &refr, &refr, &p);
+        let data = enc.finish();
+        let mut dec = MqDecoder::new(&data);
+        let mut cx = vec![0u8; 1 << 13];
+        let out = decode_refinement(&mut dec, &mut cx, refr.width, refr.height, &refr, &p).unwrap();
+        assert_eq!(out.data, refr.data);
+    }
+
+    /// Immediate generic refinement region segment (type 42) refining the page.
+    #[test]
+    fn end_to_end_refinement_region_over_page() {
+        // Page starts with a generic region (a 8x6 box); a refinement region
+        // then refines that page area into a slightly different shape.
+        let initial = bitmap_from(&[
+            "........", ".#####..", ".#...#..", ".#...#..", ".#####..", "........",
+        ]);
+        let refined = bitmap_from(&[
+            "..###...", ".#...#..", ".#...#..", ".#...#..", ".#####..", "...#....",
+        ]);
+        let mut stream = segment(0, 48, &[], 1, &page_info_payload(8, 6, 0));
+        stream.extend_from_slice(&segment(
+            1,
+            38,
+            &[],
+            1,
+            &generic_region_payload(&initial, 0, false),
+        ));
+        // Refinement region payload: region info, flags (template 1), then MQ.
+        let mut payload = region_info(8, 6, 0, 0, 4); // op REPLACE on the page
+        payload.push(0x01); // GRTEMPLATE 1, TPGRON off
+        let p = RefinementParams {
+            template: 1,
+            tpgron: false,
+            at: nominal_refine_at(),
+            dx: 0,
+            dy: 0,
+        };
+        let mut enc = MqEncoder::new();
+        let mut cx = vec![0u8; 1 << 13];
+        encode_refinement(&mut enc, &mut cx, &refined, &initial, &p);
+        payload.extend_from_slice(&enc.finish());
+        stream.extend_from_slice(&segment(2, 42, &[], 1, &payload));
+        let out = decode(&stream, &Jbig2Params { globals: None }).unwrap();
+        // The refinement region REPLACEs the page area with the refined art.
+        assert_eq!(
+            out,
+            packed_from(&["..###...", ".#...#..", ".#...#..", ".#...#..", ".#####..", "...#....",])
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Symbol dictionary refinement / aggregation (step 2).
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn symbol_dict_refagg_refines_input_symbol() {
+        // Build a refagg dictionary by hand so the refinement bytes line up
+        // with the chosen reference. One input symbol; the new symbol is its
+        // refinement.
+        let input = bitmap_from(&["####", "#..#", "#..#", "####"]);
+        let target = bitmap_from(&["####", "#..#", "#.##", "####"]);
+
+        // flags: SDREFAGG=1, SDRTEMPLATE=1.
+        let mut p = Vec::new();
+        let flags: u16 = 0x0002 | (1 << 12);
+        p.extend_from_slice(&flags.to_be_bytes());
+        for &(ax, ay) in nominal_at(0).iter() {
+            p.push(ax as u8);
+            p.push(ay as u8);
+        }
+        p.extend_from_slice(&1u32.to_be_bytes()); // SDNUMEXSYMS
+        p.extend_from_slice(&1u32.to_be_bytes()); // SDNUMNEWSYMS
+
+        let code_len = ceil_log2(2).max(1); // input(1) + new(1) = 2 → 1 bit
+        let mut enc = MqEncoder::new();
+        let mut cx_gr = vec![0u8; 1 << 13];
+        let mut iadh = vec![0u8; INT_CTX_SIZE];
+        let mut iadw = vec![0u8; INT_CTX_SIZE];
+        let mut iaex = vec![0u8; INT_CTX_SIZE];
+        let mut iaai = vec![0u8; INT_CTX_SIZE];
+        let mut iardx = vec![0u8; INT_CTX_SIZE];
+        let mut iardy = vec![0u8; INT_CTX_SIZE];
+        let mut iaid = vec![0u8; 1usize << (code_len + 1)];
+
+        encode_int(&mut enc, &mut iadh, Some(target.height as i64));
+        encode_int(&mut enc, &mut iadw, Some(target.width as i64));
+        encode_int(&mut enc, &mut iaai, Some(1)); // one aggregate instance
+        encode_iaid(&mut enc, &mut iaid, code_len, 0); // refine input symbol 0
+        encode_int(&mut enc, &mut iardx, Some(0));
+        encode_int(&mut enc, &mut iardy, Some(0));
+        encode_refinement(
+            &mut enc,
+            &mut cx_gr,
+            &target,
+            &input,
+            &RefinementParams {
+                template: 1,
+                tpgron: false,
+                at: nominal_refine_at(),
+                dx: 0,
+                dy: 0,
+            },
+        );
+        encode_int(&mut enc, &mut iadw, None); // OOB ends the height class
+        encode_int(&mut enc, &mut iaex, Some(1)); // skip the input symbol
+        encode_int(&mut enc, &mut iaex, Some(1)); // export the new symbol
+        p.extend_from_slice(&enc.finish());
+
+        // Compose: globals carry the input symbol dictionary; page stream has
+        // the refagg dictionary (referring to the input) and a text region.
+        let input_dict = symbol_dict_payload(&[&input]);
+        let mut stream = segment(0, 48, &[], 1, &page_info_payload(8, 4, 0));
+        stream.extend_from_slice(&segment(1, 0, &[], 1, &input_dict));
+        stream.extend_from_slice(&segment(2, 0, &[1], 1, &p));
+        stream.extend_from_slice(&segment(
+            3,
+            6,
+            &[2],
+            1,
+            &text_region_payload(8, 4, 1, &[(0, 0)]),
+        ));
+        let out = decode(&stream, &Jbig2Params { globals: None }).unwrap();
+        assert_eq!(
+            out,
+            packed_from(&["####....", "#..#....", "#.##....", "####...."])
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Text region per-instance refinement (step 3).
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn text_region_per_instance_refinement() {
+        // One symbol placed once, refined in place into a different bitmap.
+        let sym = bitmap_from(&["####", "#..#", "#..#", "####"]);
+        let refined = bitmap_from(&["####", "##.#", "#..#", "####"]);
+
+        let dict = symbol_dict_payload(&[&sym]);
+
+        // Text region with SBREFINE = 1, SBRTEMPLATE = 1.
+        let mut p = region_info(4, 4, 0, 0, 0);
+        let flags: u16 = (1 << 4) /* TOPLEFT */ | 0x0002 /* SBREFINE */ | (1 << 15) /* SBRTEMPLATE */;
+        p.extend_from_slice(&flags.to_be_bytes());
+        // SBRTEMPLATE = 1 → no refinement AT pixels in the header.
+        p.extend_from_slice(&1u32.to_be_bytes()); // SBNUMINSTANCES
+
+        let code_len = ceil_log2(1).max(1);
+        let mut enc = MqEncoder::new();
+        let mut iadt = vec![0u8; INT_CTX_SIZE];
+        let mut iafs = vec![0u8; INT_CTX_SIZE];
+        let mut iads = vec![0u8; INT_CTX_SIZE];
+        let mut iari = vec![0u8; INT_CTX_SIZE];
+        let mut iardw = vec![0u8; INT_CTX_SIZE];
+        let mut iardh = vec![0u8; INT_CTX_SIZE];
+        let mut iardx = vec![0u8; INT_CTX_SIZE];
+        let mut iardy = vec![0u8; INT_CTX_SIZE];
+        let mut iaid = vec![0u8; 1usize << (code_len + 1)];
+        let mut cx_gr = vec![0u8; 1 << 13];
+
+        encode_int(&mut enc, &mut iadt, Some(0)); // STRIPT
+        encode_int(&mut enc, &mut iadt, Some(0)); // strip DT
+        encode_int(&mut enc, &mut iafs, Some(0)); // first S
+        encode_iaid(&mut enc, &mut iaid, code_len, 0);
+        encode_int(&mut enc, &mut iari, Some(1)); // RI != 0 → refine
+        encode_int(&mut enc, &mut iardw, Some(0)); // same width
+        encode_int(&mut enc, &mut iardh, Some(0)); // same height
+        encode_int(&mut enc, &mut iardx, Some(0));
+        encode_int(&mut enc, &mut iardy, Some(0));
+        // dx = floor(0/2)+0 = 0, dy = 0.
+        encode_refinement(
+            &mut enc,
+            &mut cx_gr,
+            &refined,
+            &sym,
+            &RefinementParams {
+                template: 1,
+                tpgron: false,
+                at: nominal_refine_at(),
+                dx: 0,
+                dy: 0,
+            },
+        );
+        encode_int(&mut enc, &mut iads, None); // OOB ends the strip
+        p.extend_from_slice(&enc.finish());
+
+        let mut stream = segment(0, 48, &[], 1, &page_info_payload(4, 4, 0));
+        stream.extend_from_slice(&segment(1, 0, &[], 1, &dict));
+        stream.extend_from_slice(&segment(2, 6, &[1], 1, &p));
+        let out = decode(&stream, &Jbig2Params { globals: None }).unwrap();
+        assert_eq!(out, packed_from(&["####", "##.#", "#..#", "####"]));
+    }
+
+    // -----------------------------------------------------------------------
+    // Huffman decoding (step 4).
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn standard_huff_tables_round_trip() {
+        // Encode and decode representative values through every standard table.
+        for n in 1..=15usize {
+            let tab = standard_huff_table(n);
+            // Pick values inside the table's coverage from each line's low.
+            let samples: Vec<Option<i64>> = tab
+                .lines
+                .iter()
+                .filter(|l| l.prefix_len > 0)
+                .map(|l| {
+                    if l.is_oob {
+                        None
+                    } else {
+                        Some(l.range_low as i64)
+                    }
+                })
+                .collect();
+            let mut bw = BitWriter::new();
+            for v in &samples {
+                huff_encode(&mut bw, &tab, *v);
+            }
+            let data = bw.finish();
+            let mut br = BitReader::new(&data);
+            for v in &samples {
+                assert_eq!(tab.decode(&mut br), *v, "table B.{n} value {v:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn custom_huff_table_round_trip() {
+        // Build a type-53 custom table segment, parse it, and round-trip values.
+        // Flags: OOB present, prefix size 4 bits, range size 3 bits.
+        let oob = 1u8;
+        let prefix_size = 4u8;
+        let range_size = 3u8;
+        let flags = oob | ((prefix_size - 1) << 1) | ((range_size - 1) << 4);
+        let low = 0i32;
+        let high = 8i32;
+        let mut seg = Vec::new();
+        seg.push(flags);
+        seg.extend_from_slice(&(low as u32).to_be_bytes());
+        seg.extend_from_slice(&(high as u32).to_be_bytes());
+        // Code lengths via a bit writer: lines for cur=0..high in steps of
+        // 2^range_len. With range_len = 1, values 0..8 → 8 normal lines.
+        let mut bw = BitWriter::new();
+        // 8 normal lines, each prefix_len=4, range_len=1 (covers 2 values).
+        // cur advances by 2 each line → 4 lines reach high=8.
+        for _ in 0..4 {
+            bw.write_bits(4, prefix_size as u32); // prefix length 4
+            bw.write_bits(1, range_size as u32); // range length 1
+        }
+        bw.write_bits(4, prefix_size as u32); // lower-range prefix length
+        bw.write_bits(4, prefix_size as u32); // upper-range prefix length
+        bw.write_bits(4, prefix_size as u32); // OOB prefix length
+        seg.extend_from_slice(&bw.finish());
+
+        let tab = parse_custom_huff_table(&seg).unwrap();
+        let samples = [Some(0i64), Some(1), Some(4), Some(7), None];
+        let mut wb = BitWriter::new();
+        for v in &samples {
+            huff_encode(&mut wb, &tab, *v);
+        }
+        let data = wb.finish();
+        let mut br = BitReader::new(&data);
+        for v in &samples {
+            assert_eq!(tab.decode(&mut br), *v, "custom table value {v:?}");
+        }
+    }
+
+    /// Huffman symbol-dictionary payload with a hand-coded MMR collective
+    /// bitmap. The height class holds the supplied symbols (equal height); the
+    /// caller provides the matching MMR bytes for their concatenation.
+    fn huff_symbol_dict_payload(widths: &[usize], height: usize, mmr: &[u8]) -> Vec<u8> {
+        // flags: SDHUFF=1; DH=B.4(0), DW=B.2(0), BMSIZE=B.1(0), AGG=0.
+        let flags: u16 = 0x0001;
+        let mut p = Vec::new();
+        p.extend_from_slice(&flags.to_be_bytes());
+        p.extend_from_slice(&(widths.len() as u32).to_be_bytes()); // SDNUMEXSYMS
+        p.extend_from_slice(&(widths.len() as u32).to_be_bytes()); // SDNUMNEWSYMS
+
+        let dh_tab = standard_huff_table(4);
+        let dw_tab = standard_huff_table(2);
+        let bm_tab = standard_huff_table(1);
+
+        let mut bw = BitWriter::new();
+        huff_encode(&mut bw, &dh_tab, Some(height as i64)); // HCHEIGHT delta from 0
+        let mut prev_w = 0i64;
+        for &w in widths {
+            huff_encode(&mut bw, &dw_tab, Some(w as i64 - prev_w));
+            prev_w = w as i64;
+        }
+        huff_encode(&mut bw, &dw_tab, None); // OOB ends the height class
+                                             // BMSIZE: use the explicit byte count so the decoder knows the span.
+        huff_encode(&mut bw, &bm_tab, Some(mmr.len() as i64));
+        bw.byte_align();
+        p.extend_from_slice(&bw.finish());
+        p.extend_from_slice(mmr);
+
+        // Export flags (table B.1) on the same bit stream, byte-aligned after
+        // the collective bitmap: skip 0, export all.
+        let mut bw2 = BitWriter::new();
+        huff_encode(&mut bw2, &bm_tab, Some(0));
+        huff_encode(&mut bw2, &bm_tab, Some(widths.len() as i64));
+        p.extend_from_slice(&bw2.finish());
+        p
+    }
+
+    #[test]
+    fn huff_symbol_dict_and_text_region() {
+        // Reuse the known T.6 fixture: two rows "WWWBBWWW" → 0x31 0xF8. As a
+        // collective bitmap that is a single 8x2 symbol with black at cols 3-4.
+        // We export it and place it via an arithmetic text region.
+        let mmr = [0x31u8, 0xF8];
+        let dict = huff_symbol_dict_payload(&[8], 2, &mmr);
+        let mut stream = segment(0, 48, &[], 1, &page_info_payload(8, 2, 0));
+        stream.extend_from_slice(&segment(1, 0, &[], 1, &dict));
+        stream.extend_from_slice(&segment(
+            2,
+            6,
+            &[1],
+            1,
+            &text_region_payload(8, 2, 1, &[(0, 0)]),
+        ));
+        let out = decode(&stream, &Jbig2Params { globals: None }).unwrap();
+        // The symbol is WWWBBWWW on both rows (black at cols 3-4).
+        assert_eq!(out, packed_from(&["...##...", "...##..."]));
+    }
+
+    #[test]
+    fn pattern_dict_and_halftone_round_trip() {
+        // 2x2 patterns, 4 of them (HDMAX=3 → 2 bitplanes). Build a pattern
+        // dictionary and a halftone region selecting patterns by gray value.
+        let p0 = bitmap_from(&["..", ".."]); // gray 0 (white)
+        let p1 = bitmap_from(&["#.", ".."]); // gray 1
+        let p2 = bitmap_from(&["#.", ".#"]); // gray 2
+        let p3 = bitmap_from(&["##", "##"]); // gray 3 (black)
+        let patterns = [&p0, &p1, &p2, &p3];
+
+        // Pattern dictionary payload (arithmetic, template 0).
+        let hdpw = 2u8;
+        let hdph = 2u8;
+        let hdmax = 3u32;
+        let mut pd = Vec::new();
+        pd.push(0x00); // flags: MMR=0, template 0
+        pd.push(hdpw);
+        pd.push(hdph);
+        pd.extend_from_slice(&hdmax.to_be_bytes());
+        // Collective bitmap: patterns side by side (8x2).
+        let mut collective = Bitmap::new((hdpw as usize) * 4, hdph as usize, 0).unwrap();
+        for (i, pat) in patterns.iter().enumerate() {
+            for yy in 0..hdph as usize {
+                for xx in 0..hdpw as usize {
+                    if pat.get(xx as i64, yy as i64) != 0 {
+                        collective.set(i * hdpw as usize + xx, yy, 1);
+                    }
+                }
+            }
+        }
+        let at = [(-(hdpw as i64) as i8, 0i8), (-3, -1), (2, -2), (-2, -2)];
+        let mut enc = MqEncoder::new();
+        let mut cx = vec![0u8; 1 << 16];
+        encode_generic(
+            &mut enc,
+            &mut cx,
+            &collective,
+            &GenericParams {
+                template: 0,
+                tpgdon: false,
+                at,
+            },
+        );
+        pd.extend_from_slice(&enc.finish());
+
+        // Halftone region: 2x2 grid, HRX=HRY*256 so each cell is at (n*2, m*2).
+        // Gray values: top-left=1, top-right=2, bottom-left=0, bottom-right=3.
+        let gray = [[1u32, 2], [0, 3]];
+        let hgw = 2usize;
+        let hgh = 2usize;
+        let mut ht = region_info(4, 4, 0, 0, 0);
+        ht.push(0x00); // flags: MMR=0, template 0, no skip, OR, def_pixel 0
+        ht.extend_from_slice(&(hgw as u32).to_be_bytes());
+        ht.extend_from_slice(&(hgh as u32).to_be_bytes());
+        ht.extend_from_slice(&0u32.to_be_bytes()); // HGX
+        ht.extend_from_slice(&0u32.to_be_bytes()); // HGY
+        ht.extend_from_slice(&((2u16) << 8).to_be_bytes()); // HRX = 2.0 (fixed 8.8)
+        ht.extend_from_slice(&0u16.to_be_bytes()); // HRY = 0
+                                                   // Encode the grayscale image as 2 Gray-coded bitplanes (MSB first).
+        let hbpp = 2usize;
+        let mut enc2 = MqEncoder::new();
+        let mut cx2 = vec![0u8; 1 << 16];
+        let at2 = [(3i8, -1i8), (-3, -1), (2, -2), (-2, -2)];
+        // Build planes from gray via Gray code: g = v ^ (v>>1).
+        for j in (0..hbpp).rev() {
+            let mut plane = Bitmap::new(hgw, hgh, 0).unwrap();
+            for (m, row) in gray.iter().enumerate() {
+                for (n, &v) in row.iter().enumerate() {
+                    let g = v ^ (v >> 1);
+                    if (g >> j) & 1 == 1 {
+                        plane.set(n, m, 1);
+                    }
+                }
+            }
+            encode_generic(
+                &mut enc2,
+                &mut cx2,
+                &plane,
+                &GenericParams {
+                    template: 0,
+                    tpgdon: false,
+                    at: at2,
+                },
+            );
+        }
+        ht.extend_from_slice(&enc2.finish());
+
+        let mut stream = segment(0, 48, &[], 1, &page_info_payload(4, 4, 0));
+        stream.extend_from_slice(&segment(1, 16, &[], 1, &pd)); // pattern dict
+        stream.extend_from_slice(&segment(2, 22, &[1], 1, &ht)); // halftone region
+        let out = decode(&stream, &Jbig2Params { globals: None }).unwrap();
+        // Expected page: cell (m,n) draws pattern[gray[m][n]] at (n*2, m*2).
+        // gray = [[1,2],[0,3]] → patterns p1,p2 (top), p0,p3 (bottom).
+        let expected = packed_from(&[
+            "#.#.", // p1 row0 (#.) | p2 row0 (#.)
+            "...#", // p1 row1 (..) | p2 row1 (.#)
+            "..##", // p0 row0 (..) | p3 row0 (##)
+            "..##", // p0 row1 (..) | p3 row1 (##)
+        ]);
+        assert_eq!(out, expected);
     }
 }

--- a/crates/zpdf-parser/src/recovery.rs
+++ b/crates/zpdf-parser/src/recovery.rs
@@ -190,16 +190,19 @@ fn root_points_at_catalog(
     limits: &ParseLimits,
 ) -> bool {
     let obj = match table.get(root) {
-        Some(XrefEntry::InUse { offset, .. }) => {
-            ObjectParser::new(data, limits).parse_indirect_at(*offset as usize).ok()
-        }
+        Some(XrefEntry::InUse { offset, .. }) => ObjectParser::new(data, limits)
+            .parse_indirect_at(*offset as usize)
+            .ok(),
         Some(XrefEntry::Compressed {
             stream_obj,
             index_in_stream,
         }) => decode_objstm_member(data, table, *stream_obj, *index_in_stream, limits),
         _ => None,
     };
-    obj.as_ref().map(object_dict).map(dict_is_catalog).unwrap_or(false)
+    obj.as_ref()
+        .map(object_dict)
+        .map(dict_is_catalog)
+        .unwrap_or(false)
 }
 
 /// Find the LAST `trailer` keyword in the buffer and lex the following dict.
@@ -246,7 +249,8 @@ fn find_catalog(
             index_in_stream,
         }) = table.get(id)
         {
-            if let Some(obj) = decode_objstm_member(data, table, *stream_obj, *index_in_stream, limits)
+            if let Some(obj) =
+                decode_objstm_member(data, table, *stream_obj, *index_in_stream, limits)
             {
                 if dict_is_catalog(object_dict(&obj)) {
                     best = Some((id, None));
@@ -330,7 +334,9 @@ fn decode_objstm_member(
     if start > end {
         return None;
     }
-    Lexer::new(&decoded[start..end], 0, limits).next_token().ok()
+    Lexer::new(&decoded[start..end], 0, limits)
+        .next_token()
+        .ok()
 }
 
 /// For each recovered /Type /ObjStm object, decode it and add Compressed entries

--- a/crates/zpdf-render-cpu/src/lib.rs
+++ b/crates/zpdf-render-cpu/src/lib.rs
@@ -131,6 +131,8 @@ enum ClipFrame {
 const MAX_CLIP_PIXEL_WORK: u64 = 2_000_000_000;
 
 struct BlendEntry {
+    /// The parked parent raster (the group's backdrop), restored and composited
+    /// onto at `pop`. A 1×1 placeholder for a `passthrough` entry.
     pixmap: tiny_skia::Pixmap,
     blend_mode: BlendMode,
     /// Group constant alpha applied at composite time.
@@ -138,6 +140,16 @@ struct BlendEntry {
     /// Rasterized soft-mask coverage (one byte per pixel), multiplied into the
     /// group before compositing.
     mask: Option<Vec<u8>>,
+    /// Knockout group: each element composites against the group's initial
+    /// backdrop rather than the accumulation of preceding elements.
+    knockout: bool,
+    /// The group's initial backdrop (`b0`) for per-element knockout compositing
+    /// (`Some` only for knockout groups).
+    backdrop: Option<tiny_skia::Pixmap>,
+    /// A non-isolated group with no group-level effect (Normal blend, alpha 1,
+    /// no mask, no knockout): its elements draw straight onto the canvas, so no
+    /// buffer is parked and `pop` is a no-op.
+    passthrough: bool,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -300,7 +312,21 @@ impl<'a> CpuRenderer<'a> {
             Paint::Solid(c) => Self::color_to_paint(c, alpha),
             _ => return,
         };
-        let stroke = tiny_skia::Stroke {
+        let stroke = self.build_skia_stroke(style);
+        if let Some(ref mut pixmap) = self.pixmap {
+            pixmap.stroke_path(
+                &skia_path,
+                &paint,
+                &stroke,
+                tiny_skia::Transform::identity(),
+                self.current_clip.as_ref(),
+            );
+        }
+    }
+
+    /// Device-space tiny-skia stroke parameters for `style`.
+    fn build_skia_stroke(&self, style: &StrokeStyle) -> tiny_skia::Stroke {
+        tiny_skia::Stroke {
             // Hairline boost: never let a stroke fall below one device pixel
             // (matches pdfium; keeps thin diagram strokes legible at low DPI,
             // and renders PDF zero-width strokes as 1px hairlines).
@@ -317,15 +343,6 @@ impl<'a> CpuRenderer<'a> {
             },
             miter_limit: style.miter_limit,
             dash: self.build_stroke_dash(style),
-        };
-        if let Some(ref mut pixmap) = self.pixmap {
-            pixmap.stroke_path(
-                &skia_path,
-                &paint,
-                &stroke,
-                tiny_skia::Transform::identity(),
-                self.current_clip.as_ref(),
-            );
         }
     }
 
@@ -448,9 +465,109 @@ impl<'a> CpuRenderer<'a> {
         }
     }
 
-    fn push_blend_group(&mut self, blend_mode: BlendMode, alpha: f32, mask: Option<&SoftMask>) {
+    /// Intersect the clip with a stroked path's outline. tiny-skia masks cannot
+    /// stroke directly, so the stroke is rasterized into a scratch pixmap and
+    /// its alpha lifted into a coverage mask. Used to clip pattern/shading
+    /// paints to a stroke.
+    fn push_clip_stroke(&mut self, path: &Path, style: &StrokeStyle) {
+        let Some(pixmap) = self.pixmap.as_ref() else {
+            return;
+        };
+        let (pw, ph) = (pixmap.width(), pixmap.height());
+
+        if self.clip_pixel_spent >= MAX_CLIP_PIXEL_WORK {
+            self.clip_stack.push(ClipFrame::Skipped);
+            return;
+        }
+        let Some(skia_path) = self.build_skia_path(path) else {
+            self.clip_stack.push(ClipFrame::Skipped);
+            return;
+        };
+        let Some(mut scratch) = tiny_skia::Pixmap::new(pw, ph) else {
+            self.clip_stack.push(ClipFrame::Skipped);
+            return;
+        };
+        self.clip_pixel_spent += pw as u64 * ph as u64;
+
+        let mut paint = tiny_skia::Paint::default();
+        paint.set_color(tiny_skia::Color::WHITE);
+        paint.anti_alias = true;
+        let stroke = self.build_skia_stroke(style);
+        scratch.stroke_path(
+            &skia_path,
+            &paint,
+            &stroke,
+            tiny_skia::Transform::identity(),
+            None,
+        );
+        let mut mask = tiny_skia::Mask::from_pixmap(scratch.as_ref(), tiny_skia::MaskType::Alpha);
+
+        // Intersect with the active clip over the stroke's device bbox (the
+        // centerline bounds grown by the stroke width). Outside that box the
+        // stroke mask is already 0, so the intersection is 0 there too.
+        if let Some(ref current) = self.current_clip {
+            let b = skia_path.bounds();
+            let grow = stroke.width.max(1.0);
+            let w = pw as usize;
+            let h = ph as usize;
+            let x0 = ((b.left() - grow).floor().max(0.0) as usize).min(w);
+            let x1 = ((b.right() + grow).ceil().max(0.0) as usize).min(w);
+            let y0 = ((b.top() - grow).floor().max(0.0) as usize).min(h);
+            let y1 = ((b.bottom() + grow).ceil().max(0.0) as usize).min(h);
+            let current_data = current.data();
+            let mask_data = mask.data_mut();
+            for y in y0..y1 {
+                let row = y * w;
+                for x in x0..x1 {
+                    let i = row + x;
+                    mask_data[i] = ((mask_data[i] as u16 * current_data[i] as u16) / 255) as u8;
+                }
+            }
+        }
+
+        let frame = match self.current_clip.take() {
+            Some(old) => ClipFrame::Mask(old),
+            None => ClipFrame::Empty,
+        };
+        self.clip_stack.push(frame);
+        self.current_clip = Some(mask);
+    }
+
+    fn push_blend_group(
+        &mut self,
+        blend_mode: BlendMode,
+        isolated: bool,
+        knockout: bool,
+        alpha: f32,
+        mask: Option<&SoftMask>,
+    ) {
         // Rasterize the soft mask before parking the base pixmap (needs dims).
         let mask_plane = mask.and_then(|m| self.soft_mask_plane(m));
+
+        // A non-isolated group with no group-as-a-unit operation (Normal blend,
+        // full alpha, no soft mask, not knockout) is exactly equivalent to
+        // drawing its elements straight onto the backdrop — and that is the only
+        // way element-level blend modes inside it correctly see the backdrop.
+        // Park nothing; a 1×1 sentinel keeps push/pop balanced.
+        let passthrough = !isolated
+            && !knockout
+            && blend_mode == BlendMode::Normal
+            && alpha >= 1.0
+            && mask_plane.is_none();
+        if passthrough {
+            if let Some(sentinel) = tiny_skia::Pixmap::new(1, 1) {
+                self.blend_stack.push(BlendEntry {
+                    pixmap: sentinel,
+                    blend_mode,
+                    alpha,
+                    mask: None,
+                    knockout: false,
+                    backdrop: None,
+                    passthrough: true,
+                });
+            }
+            return;
+        }
 
         let pixmap = match self.pixmap.take() {
             Some(p) => p,
@@ -459,14 +576,27 @@ impl<'a> CpuRenderer<'a> {
         let w = pixmap.width();
         let h = pixmap.height();
 
+        // The group renders into its own transparent buffer (isolated). A
+        // non-isolated group that reached this point carries a group-level
+        // effect (alpha/mask/blend) and is approximated as isolated — element
+        // blends against the backdrop are the rare loss. `None` on allocation
+        // failure degrades to a no-op group, which `pop_blend_group` handles.
+        let group = tiny_skia::Pixmap::new(w, h);
+        // Per-element knockout composites against the (transparent) initial
+        // backdrop preserved here.
+        let backdrop = if knockout { group.clone() } else { None };
+
         self.blend_stack.push(BlendEntry {
             pixmap,
             blend_mode,
             alpha,
             mask: mask_plane,
+            knockout,
+            backdrop,
+            passthrough: false,
         });
 
-        self.pixmap = tiny_skia::Pixmap::new(w, h);
+        self.pixmap = group;
     }
 
     fn pop_blend_group(&mut self) {
@@ -474,6 +604,11 @@ impl<'a> CpuRenderer<'a> {
             Some(e) => e,
             None => return,
         };
+
+        // Passthrough group: elements already drew onto the live canvas.
+        if entry.passthrough {
+            return;
+        }
 
         let mut group_pixmap = match self.pixmap.take() {
             Some(p) => p,
@@ -518,6 +653,101 @@ impl<'a> CpuRenderer<'a> {
         );
 
         self.pixmap = Some(base);
+    }
+
+    /// Dispatch the four painting commands to their renderers (shared by the
+    /// normal path and the knockout path).
+    fn render_paint_cmd(&mut self, cmd: &RenderCommand) {
+        match cmd {
+            RenderCommand::FillPath {
+                path,
+                rule,
+                paint,
+                alpha,
+            } => self.render_fill(path, rule, paint, *alpha),
+            RenderCommand::StrokePath {
+                path,
+                style,
+                paint,
+                alpha,
+            } => self.render_stroke(path, style, paint, *alpha),
+            RenderCommand::DrawGlyphRun(run) => self.render_glyph_run(run),
+            RenderCommand::DrawImage(draw) => self.render_image(draw),
+            _ => {}
+        }
+    }
+
+    /// True while the innermost open transparency group is a knockout group.
+    fn in_knockout(&self) -> bool {
+        self.blend_stack.last().map(|e| e.knockout).unwrap_or(false)
+    }
+
+    /// Render a painting command at full opacity to capture its *shape* (the
+    /// geometric/anti-aliased coverage), independent of its opacity.
+    fn render_shape_cmd(&mut self, cmd: &RenderCommand) {
+        match cmd {
+            RenderCommand::FillPath {
+                path, rule, paint, ..
+            } => self.render_fill(path, rule, paint, 1.0),
+            RenderCommand::StrokePath {
+                path, style, paint, ..
+            } => self.render_stroke(path, style, paint, 1.0),
+            RenderCommand::DrawGlyphRun(run) => {
+                let mut r = run.clone();
+                r.alpha = 1.0;
+                self.render_glyph_run(&r);
+            }
+            RenderCommand::DrawImage(draw) => {
+                let mut d = draw.clone();
+                d.alpha = 1.0;
+                self.render_image(&d);
+            }
+            _ => {}
+        }
+    }
+
+    /// Paint one element inside a knockout group: render it alone, composite it
+    /// over the group's initial backdrop, and replace the group buffer in
+    /// proportion to the element's *shape* (so it knocks out preceding elements
+    /// rather than accumulating over them). The shape — captured by a full-
+    /// opacity pass — is what PDF 11.4.9 uses, so a semi-transparent solid fill
+    /// still fully knocks out (it shows the backdrop through itself, not the
+    /// elements beneath).
+    fn knockout_paint(&mut self, cmd: &RenderCommand) {
+        let (w, h) = match self.pixmap.as_ref() {
+            Some(p) => (p.width(), p.height()),
+            None => return,
+        };
+
+        // Pass 1: the element as painted (real colour and opacity).
+        let group = self.pixmap.take();
+        self.pixmap = tiny_skia::Pixmap::new(w, h);
+        if self.pixmap.is_none() {
+            self.pixmap = group;
+            self.render_paint_cmd(cmd); // OOM: fall back to accumulation
+            return;
+        }
+        self.render_paint_cmd(cmd);
+        let elem = self.pixmap.take();
+
+        // Pass 2: the element at full opacity → its shape (alpha = coverage).
+        self.pixmap = tiny_skia::Pixmap::new(w, h);
+        if self.pixmap.is_none() {
+            self.pixmap = group;
+            return;
+        }
+        self.render_shape_cmd(cmd);
+        let shape = self.pixmap.take();
+
+        self.pixmap = group;
+        let (elem, shape) = match (elem, shape) {
+            (Some(e), Some(s)) => (e, s),
+            _ => return,
+        };
+        if let (Some(g), Some(entry)) = (self.pixmap.as_mut(), self.blend_stack.last()) {
+            let b0 = entry.backdrop.as_ref().map(|p| p.data());
+            knockout_merge(g.data_mut(), elem.data(), shape.data(), b0);
+        }
     }
 
     /// Coverage plane for `mask`, honoring its page-space offset. The base
@@ -1017,6 +1247,46 @@ impl<'a> Default for CpuRenderer<'a> {
     }
 }
 
+/// Knockout merge: `group = lerp(group, elem OVER b0, shape)`, in place,
+/// premultiplied RGBA8. `shape` carries the element's geometric coverage in its
+/// alpha channel (a full-opacity render of the same element), while `elem`
+/// carries its real premultiplied colour/opacity. `b0` is the group's initial
+/// backdrop (`None` == transparent, where `elem OVER transparent == elem`).
+/// Where shape is full, the element fully knocks out preceding elements.
+fn knockout_merge(group: &mut [u8], elem: &[u8], shape: &[u8], b0: Option<&[u8]>) {
+    let n = group.len() / 4;
+    for i in 0..n {
+        let o = i * 4;
+        let f = shape[o + 3]; // geometric coverage of this element
+        if f == 0 {
+            continue;
+        }
+        let ea = elem[o + 3];
+        let inv_e = (255 - ea) as u32; // 1 − elem.alpha
+                                       // X = elem OVER b0 (premultiplied), using the element's real opacity.
+        let x = match b0 {
+            Some(b) => [
+                elem[o] as u32 + (inv_e * b[o] as u32 + 127) / 255,
+                elem[o + 1] as u32 + (inv_e * b[o + 1] as u32 + 127) / 255,
+                elem[o + 2] as u32 + (inv_e * b[o + 2] as u32 + 127) / 255,
+                ea as u32 + (inv_e * b[o + 3] as u32 + 127) / 255,
+            ],
+            None => [
+                elem[o] as u32,
+                elem[o + 1] as u32,
+                elem[o + 2] as u32,
+                ea as u32,
+            ],
+        };
+        // group = group·(1 − shape) + X·shape.
+        let inv_f = (255 - f) as u32;
+        for c in 0..4 {
+            let v = (group[o + c] as u32 * inv_f + x[c] * f as u32 + 127) / 255;
+            group[o + c] = v.min(255) as u8;
+        }
+    }
+}
+
 /// Box-filter (area-average) downscale of a tight RGBA8 buffer. Each target
 /// pixel averages its covering source block, so no source pixel is dropped —
 /// unlike point/bilinear sampling at strong minification. Channels are averaged
@@ -1077,9 +1347,11 @@ impl<'a> RenderBackend for CpuRenderer<'a> {
         self.rect_x0 = info.page_rect.x0 as f32;
         self.rect_y0 = info.page_rect.y0 as f32;
         self.rect_y1 = info.page_rect.y1 as f32;
-        // Fresh clip state + budget for each page (a renderer may be reused).
+        // Fresh clip + blend state + budget for each page (a renderer may be
+        // reused). An unbalanced group from a prior page must not leak through.
         self.clip_stack.clear();
         self.current_clip = None;
+        self.blend_stack.clear();
         self.clip_pixel_spent = 0;
         self.over_budget = false;
         self.deadline = self.render_budget.map(|d| std::time::Instant::now() + d);
@@ -1140,42 +1412,48 @@ impl<'a> RenderBackend for CpuRenderer<'a> {
                 return Ok(());
             }
         }
+
+        // Inside a knockout group each painting element composites against the
+        // group's initial backdrop rather than the accumulation of preceding
+        // elements: route paints through the per-element knockout path.
+        if self.in_knockout()
+            && matches!(
+                cmd,
+                RenderCommand::FillPath { .. }
+                    | RenderCommand::StrokePath { .. }
+                    | RenderCommand::DrawGlyphRun(_)
+                    | RenderCommand::DrawImage(_)
+            )
+        {
+            self.knockout_paint(cmd);
+            return Ok(());
+        }
+
         match cmd {
-            RenderCommand::FillPath {
-                path,
-                rule,
-                paint,
-                alpha,
-            } => {
-                self.render_fill(path, rule, paint, *alpha);
-            }
-            RenderCommand::StrokePath {
-                path,
-                style,
-                paint,
-                alpha,
-            } => {
-                self.render_stroke(path, style, paint, *alpha);
-            }
-            RenderCommand::DrawGlyphRun(glyph_run) => {
-                self.render_glyph_run(glyph_run);
-            }
-            RenderCommand::DrawImage(image_draw) => {
-                self.render_image(image_draw);
+            RenderCommand::FillPath { .. }
+            | RenderCommand::StrokePath { .. }
+            | RenderCommand::DrawGlyphRun(_)
+            | RenderCommand::DrawImage(_) => {
+                self.render_paint_cmd(cmd);
             }
             RenderCommand::PushClip { path, rule } => {
                 self.push_clip(path, rule);
+            }
+            RenderCommand::PushClipStroke { path, style } => {
+                self.push_clip_stroke(path, style);
             }
             RenderCommand::PopClip => {
                 self.pop_clip();
             }
             RenderCommand::PushBlendGroup {
                 blend_mode,
+                isolated,
+                knockout,
                 alpha,
                 mask,
                 ..
             } => {
-                self.push_blend_group(*blend_mode, *alpha, mask.as_ref());
+                self.push_blend_group(*blend_mode, *isolated, *knockout, *alpha, mask.as_ref());
             }
             RenderCommand::PopBlendGroup => {
                 self.pop_blend_group();

--- a/crates/zpdf-render-wgpu/src/lib.rs
+++ b/crates/zpdf-render-wgpu/src/lib.rs
@@ -168,6 +168,8 @@ impl<'a> RenderBackend for WgpuRenderer<'a> {
     }
 
     fn execute(&mut self, cmd: &RenderCommand) -> Result<(), Self::Error> {
+        let fonts = self.font_cache;
+        let images = self.image_cache;
         let Some(page) = self.page.as_mut() else {
             return Ok(());
         };
@@ -192,6 +194,9 @@ impl<'a> RenderBackend for WgpuRenderer<'a> {
             }
             RenderCommand::PushClip { path, rule } => {
                 page.recorder.push_clip(path, *rule, &page.map);
+            }
+            RenderCommand::PushClipStroke { path, style } => {
+                page.recorder.push_clip_stroke(path, style, &page.map);
             }
             RenderCommand::PopClip => {
                 page.recorder.pop_clip();
@@ -221,12 +226,13 @@ impl<'a> RenderBackend for WgpuRenderer<'a> {
                 mask,
                 ..
             } => {
-                // Soft masks and group alpha are CPU-only for now (Phase 3
-                // parity work); the group still composites with its blend mode.
-                if mask.is_some() || *alpha < 1.0 {
-                    tracing::debug!("wgpu backend: soft mask / group alpha not yet supported");
-                }
-                page.recorder.push_blend(*blend_mode);
+                // Record the soft mask's geometry into the shared arena (its ops
+                // are replayed into an offscreen coverage layer at composite).
+                let map = page.map;
+                let mask_ops = mask
+                    .as_ref()
+                    .and_then(|m| build_mask_ops(&mut page.recorder, m, fonts, images, &map));
+                page.recorder.push_blend(*blend_mode, *alpha, mask_ops);
             }
             RenderCommand::PopBlendGroup => {
                 page.recorder.pop_blend();
@@ -307,12 +313,12 @@ impl<'a> RenderBackend for WgpuRenderer<'a> {
         let mut tex_bgs: std::collections::HashMap<u32, wgpu::BindGroup> =
             std::collections::HashMap::new();
         if let Some(images) = self.image_cache {
-            for op in &rec.ops {
-                if let PageOp::Image { image_id, .. } = op {
-                    if tex_bgs.contains_key(image_id) {
-                        continue;
+            let upload =
+                |image_id: u32, tex_bgs: &mut std::collections::HashMap<u32, wgpu::BindGroup>| {
+                    if tex_bgs.contains_key(&image_id) {
+                        return;
                     }
-                    if let Some(img) = images.get(*image_id) {
+                    if let Some(img) = images.get(image_id) {
                         if img.width == 0
                             || img.height == 0
                             || img.width > ctx.max_texture_dim
@@ -323,10 +329,23 @@ impl<'a> RenderBackend for WgpuRenderer<'a> {
                                 img.width,
                                 img.height
                             );
-                            continue;
+                            return;
                         }
-                        tex_bgs.insert(*image_id, image::upload_image_bind_group(ctx, img));
+                        tex_bgs.insert(image_id, image::upload_image_bind_group(ctx, img));
                     }
+                };
+            for op in &rec.ops {
+                match op {
+                    PageOp::Image { image_id, .. } => upload(*image_id, &mut tex_bgs),
+                    // Images inside a soft mask reference the same shared arena.
+                    PageOp::PushBlend { mask: Some(m), .. } => {
+                        for mop in &m.ops {
+                            if let PageOp::Image { image_id, .. } = mop {
+                                upload(*image_id, &mut tex_bgs);
+                            }
+                        }
+                    }
+                    _ => {}
                 }
             }
         }
@@ -449,6 +468,89 @@ fn replay_ops(pass: &mut wgpu::RenderPass, ops: &[PageOp], res: &ReplayRes) {
     }
 }
 
+/// Record a soft mask's [`zpdf_display_list::DisplayList`] into `rec` (geometry
+/// into the shared arena, ops collected separately by the caller). Returns
+/// whether everything was recordable: a nested transparency group inside the
+/// mask is unsupported, in which case the caller drops the mask (the group then
+/// renders unmasked rather than incorrectly masked).
+fn record_dl_commands(
+    rec: &mut PageRecorder,
+    dl: &zpdf_display_list::DisplayList,
+    fonts: Option<&zpdf_font::FontCache>,
+    images: Option<&zpdf_image::ImageCache>,
+    map: &PageMap,
+) -> bool {
+    use zpdf_display_list::Paint;
+    let mut supported = true;
+    for cmd in &dl.commands {
+        match cmd {
+            RenderCommand::FillPath {
+                path,
+                rule,
+                paint: Paint::Solid(c),
+                alpha,
+            } => rec.add_fill(path, *rule, quantize_premul(c, *alpha), map),
+            RenderCommand::StrokePath {
+                path,
+                style,
+                paint: Paint::Solid(c),
+                alpha,
+            } => rec.add_stroke(path, style, quantize_premul(c, *alpha), map),
+            RenderCommand::DrawGlyphRun(run) => {
+                if let Some(f) = fonts {
+                    glyph::render_glyph_run(rec, f, map, run);
+                }
+            }
+            RenderCommand::DrawImage(draw) => {
+                if let Some(img) = images.and_then(|c| c.get(draw.image_id)) {
+                    let quad = image::image_quad(
+                        img.width as f32,
+                        img.height as f32,
+                        &draw.transform,
+                        map,
+                        draw.alpha,
+                    );
+                    rec.add_image(quad, draw.image_id);
+                }
+            }
+            RenderCommand::PushClip { path, rule } => rec.push_clip(path, *rule, map),
+            RenderCommand::PushClipStroke { path, style } => rec.push_clip_stroke(path, style, map),
+            RenderCommand::PopClip => rec.pop_clip(),
+            // Pattern fills (non-solid paint) are already expanded to clip+fill
+            // by the interpreter, so a non-solid paint here is a rare no-op.
+            RenderCommand::FillPath { .. } | RenderCommand::StrokePath { .. } => {}
+            // A nested group inside a mask is not supported on the GPU path.
+            RenderCommand::PushBlendGroup { .. } | RenderCommand::PopBlendGroup => {
+                supported = false;
+            }
+        }
+    }
+    supported
+}
+
+/// Build the [`record::MaskOps`] for a group's soft mask, or `None` to render the
+/// group unmasked (mask had unsupported content, e.g. a nested group).
+fn build_mask_ops(
+    rec: &mut PageRecorder,
+    mask: &zpdf_display_list::SoftMask,
+    fonts: Option<&zpdf_font::FontCache>,
+    images: Option<&zpdf_image::ImageCache>,
+    map: &PageMap,
+) -> Option<record::MaskOps> {
+    let mut supported = true;
+    let ops = rec.record_subops(|r| {
+        supported = record_dl_commands(r, &mask.commands, fonts, images, map);
+    });
+    if !supported {
+        return None;
+    }
+    Some(record::MaskOps {
+        ops,
+        kind: mask.kind,
+        backdrop_luma: mask.backdrop_luma,
+    })
+}
+
 /// Stamp clip paths into the current pass's stencil (clip_write pipeline).
 fn stamp_clips(pass: &mut wgpu::RenderPass, clips: &[record::ClipStamp], res: &ReplayRes) {
     let Some((svb, sib)) = res.solid else {
@@ -519,7 +621,12 @@ fn render_layered(
 
     let mut layers: Vec<blend::RenderLayer> = vec![blend::RenderLayer::new(device, w, h, sc)];
     let mut active: Vec<usize> = vec![0];
-    let mut blend_info: Vec<(zpdf_display_list::BlendMode, Vec<record::ClipStamp>)> = Vec::new();
+    let mut blend_info: Vec<(
+        zpdf_display_list::BlendMode,
+        f32,
+        Option<&record::MaskOps>,
+        Vec<record::ClipStamp>,
+    )> = Vec::new();
     // Composite bind groups + mode buffers kept alive until submit.
     let mut keep_bgs: Vec<wgpu::BindGroup> = Vec::new();
     let mut keep_bufs: Vec<wgpu::Buffer> = Vec::new();
@@ -560,7 +667,12 @@ fn render_layered(
             break;
         }
         match &ops[i] {
-            PageOp::PushBlend { mode, clips } => {
+            PageOp::PushBlend {
+                mode,
+                alpha,
+                clips,
+                mask,
+            } => {
                 let g = layers.len();
                 layers.push(blend::RenderLayer::new(device, w, h, sc));
                 init_layer(
@@ -571,21 +683,50 @@ fn render_layered(
                     res,
                 );
                 active.push(g);
-                blend_info.push((*mode, clips.clone()));
+                blend_info.push((*mode, *alpha, mask.as_ref(), clips.clone()));
             }
             PageOp::PopBlend => {
                 let group = active.pop().unwrap_or(0);
-                let (mode, clips) = blend_info
-                    .pop()
-                    .unwrap_or((zpdf_display_list::BlendMode::Normal, Vec::new()));
+                let (mode, alpha, mask, clips) = blend_info.pop().unwrap_or((
+                    zpdf_display_list::BlendMode::Normal,
+                    1.0,
+                    None,
+                    Vec::new(),
+                ));
                 let parent = *active.last().unwrap_or(&0);
+
+                // A soft mask pre-multiplies the group layer by per-pixel
+                // coverage: render the mask into its own layer, then an
+                // apply-mask pass writes (group × coverage) into a fresh layer
+                // that takes the group's place as the composite source.
+                let group = if let Some(m) = mask {
+                    apply_soft_mask(
+                        ctx,
+                        &mut encoder,
+                        &mut layers,
+                        group,
+                        m,
+                        (w, h, sc),
+                        res,
+                        &mut keep_bgs,
+                        &mut keep_bufs,
+                    )
+                } else {
+                    group
+                };
+
                 let scratch = layers.len();
                 layers.push(blend::RenderLayer::new(device, w, h, sc));
 
-                // Mode uniform (16-byte aligned) + composite bind group.
+                // Mode + group-alpha uniform (16-byte aligned) + composite bind group.
                 let mode_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
                     label: Some("zpdf-blend-mode"),
-                    contents: bytemuck::cast_slice(&[blend::blend_index(mode), 0u32, 0, 0]),
+                    contents: bytemuck::cast_slice(&[
+                        blend::blend_index(mode),
+                        alpha.clamp(0.0, 1.0).to_bits(),
+                        0,
+                        0,
+                    ]),
                     usage: wgpu::BufferUsages::UNIFORM,
                 });
                 let comp_bg = device.create_bind_group(&wgpu::BindGroupDescriptor {
@@ -650,6 +791,111 @@ fn render_layered(
     target.record_copy_from(&mut encoder, layers[final_layer].sampleable_texture());
     ctx.queue.submit(Some(encoder.finish()));
     target.map_and_strip(device)
+}
+
+/// Apply a group's soft mask: render the mask group into its own layer, then a
+/// fullscreen pass pre-multiplies the group layer by the mask's per-pixel
+/// coverage (luminosity over the /BC backdrop, or the mask group's alpha).
+/// Returns the index of the masked layer that takes the group's place as the
+/// composite source. New bind groups/buffers are parked in `keep_*` so they
+/// outlive the encoder submission.
+#[allow(clippy::too_many_arguments)]
+fn apply_soft_mask(
+    ctx: &GpuContext,
+    encoder: &mut wgpu::CommandEncoder,
+    layers: &mut Vec<blend::RenderLayer>,
+    group: usize,
+    mask: &record::MaskOps,
+    dims: (u32, u32, u32),
+    res: &ReplayRes,
+    keep_bgs: &mut Vec<wgpu::BindGroup>,
+    keep_bufs: &mut Vec<wgpu::Buffer>,
+) -> usize {
+    use wgpu::util::DeviceExt;
+    use zpdf_display_list::SoftMaskKind;
+    let (w, h, sc) = dims;
+    let device = &ctx.device;
+
+    // 1. Render the mask group into a fresh layer. Luminosity masks start from
+    //    the /BC backdrop luminosity (opaque); alpha masks from transparent.
+    let mask_layer = layers.len();
+    layers.push(blend::RenderLayer::new(device, w, h, sc));
+    let clear = match mask.kind {
+        SoftMaskKind::Luminosity => {
+            let l = mask.backdrop_luma.clamp(0.0, 1.0) as f64;
+            wgpu::Color {
+                r: l,
+                g: l,
+                b: l,
+                a: 1.0,
+            }
+        }
+        SoftMaskKind::Alpha => wgpu::Color::TRANSPARENT,
+    };
+    {
+        let mut pass = begin_layer_pass(
+            encoder,
+            &layers[mask_layer],
+            wgpu::LoadOp::Clear(clear),
+            wgpu::LoadOp::Clear(0),
+        );
+        replay_ops(&mut pass, &mask.ops, res);
+    }
+
+    // 2. Pre-multiply the group layer by the mask coverage into a fresh layer.
+    let masked = layers.len();
+    layers.push(blend::RenderLayer::new(device, w, h, sc));
+    let kind_id: u32 = match mask.kind {
+        SoftMaskKind::Luminosity => 1,
+        SoftMaskKind::Alpha => 2,
+    };
+    let mask_u = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: Some("zpdf-mask-kind"),
+        contents: bytemuck::cast_slice(&[kind_id, 0u32, 0, 0]),
+        usage: wgpu::BufferUsages::UNIFORM,
+    });
+    let mask_bg = device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some("zpdf-mask-apply-bg"),
+        layout: &ctx.pipelines.mask_apply_bgl,
+        entries: &[
+            wgpu::BindGroupEntry {
+                binding: 0,
+                resource: wgpu::BindingResource::TextureView(layers[group].sampleable_view()),
+            },
+            wgpu::BindGroupEntry {
+                binding: 1,
+                resource: wgpu::BindingResource::TextureView(layers[mask_layer].sampleable_view()),
+            },
+            wgpu::BindGroupEntry {
+                binding: 2,
+                resource: mask_u.as_entire_binding(),
+            },
+        ],
+    });
+    {
+        let mut pass = begin_layer_pass(
+            encoder,
+            &layers[masked],
+            wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+            wgpu::LoadOp::Clear(0),
+        );
+        pass.set_bind_group(0, Some(res.bind_group), &[]);
+        if let (Some(fs), Some((svb, sib))) = (res.fs_range, res.solid) {
+            pass.set_pipeline(&ctx.pipelines.mask_apply);
+            pass.set_bind_group(1, Some(&mask_bg), &[]);
+            pass.set_vertex_buffer(0, svb.slice(..));
+            pass.set_index_buffer(sib.slice(..), wgpu::IndexFormat::Uint32);
+            pass.set_stencil_reference(0);
+            pass.draw_indexed(
+                fs.first_index..fs.first_index + fs.index_count,
+                fs.base_vertex,
+                0..1,
+            );
+        }
+    }
+    keep_bgs.push(mask_bg);
+    keep_bufs.push(mask_u);
+    masked
 }
 
 /// Tracks the currently-bound pipeline to skip redundant `set_pipeline` calls.

--- a/crates/zpdf-render-wgpu/src/pipelines.rs
+++ b/crates/zpdf-render-wgpu/src/pipelines.rs
@@ -30,6 +30,10 @@ pub struct Pipelines {
     pub composite_bgl: wgpu::BindGroupLayout,
     /// Blend-group composite pipeline (fullscreen, reads base+group, 16 modes).
     pub composite: wgpu::RenderPipeline,
+    /// Bind group 1 (mask-apply): group texture + mask texture + kind uniform.
+    pub mask_apply_bgl: wgpu::BindGroupLayout,
+    /// Soft-mask apply pipeline (fullscreen, group × mask coverage).
+    pub mask_apply: wgpu::RenderPipeline,
 }
 
 impl Pipelines {
@@ -259,6 +263,87 @@ impl Pipelines {
             cache: None,
         });
 
+        // --- Soft-mask apply pipeline: group 1 = group texture + mask texture +
+        //     kind uniform. Same layout shape as composite. ---
+        let mask_apply_bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("zpdf-mask-apply-bgl"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: false },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: false },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 2,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+            ],
+        });
+        let mask_shader =
+            device.create_shader_module(wgpu::include_wgsl!("shaders/mask_apply.wgsl"));
+        let mask_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("zpdf-mask-apply-layout"),
+            bind_group_layouts: &[Some(&page_bgl), Some(&mask_apply_bgl)],
+            immediate_size: 0,
+        });
+        let mask_vbl = wgpu::VertexBufferLayout {
+            array_stride: std::mem::size_of::<SolidVertex>() as u64,
+            step_mode: wgpu::VertexStepMode::Vertex,
+            attributes: &attrs,
+        };
+        let mask_apply = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("zpdf-mask-apply"),
+            layout: Some(&mask_layout),
+            vertex: wgpu::VertexState {
+                module: &mask_shader,
+                entry_point: Some("vs_mask"),
+                buffers: &[mask_vbl],
+                compilation_options: Default::default(),
+            },
+            primitive: wgpu::PrimitiveState {
+                cull_mode: None,
+                ..Default::default()
+            },
+            depth_stencil: Some(composite_stencil_state()),
+            multisample: wgpu::MultisampleState {
+                count: sample_count,
+                ..Default::default()
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &mask_shader,
+                entry_point: Some("fs_mask"),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: target_format,
+                    blend: None,
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: Default::default(),
+            }),
+            multiview_mask: None,
+            cache: None,
+        });
+
         Self {
             page_bgl,
             tex_bgl,
@@ -269,6 +354,8 @@ impl Pipelines {
             textured,
             composite_bgl,
             composite,
+            mask_apply_bgl,
+            mask_apply,
         }
     }
 }

--- a/crates/zpdf-render-wgpu/src/record.rs
+++ b/crates/zpdf-render-wgpu/src/record.rs
@@ -8,7 +8,17 @@
 
 use crate::path::{fill_mesh, stroke_mesh, Mesh};
 use crate::transform::{PageMap, SolidVertex, TexturedVertex};
-use zpdf_display_list::{BlendMode, FillRule, Path as DlPath, StrokeStyle};
+use zpdf_display_list::{BlendMode, FillRule, Path as DlPath, SoftMaskKind, StrokeStyle};
+
+/// A soft mask's recorded geometry (ops referencing the shared page arena) plus
+/// the reduction parameters needed to turn it into per-pixel coverage.
+pub struct MaskOps {
+    /// Ops replayed into an offscreen mask layer (reference the shared buffers).
+    pub ops: Vec<PageOp>,
+    pub kind: SoftMaskKind,
+    /// /BC backdrop luminosity for areas the mask group leaves unpainted.
+    pub backdrop_luma: f32,
+}
 
 /// A range of indices/vertices in the shared arena.
 #[derive(Clone, Copy)]
@@ -41,9 +51,13 @@ pub enum PageOp {
     },
     /// Begin a transparency group: subsequent ops render to a fresh offscreen layer.
     /// `clips` are the clip paths active at push time, re-stamped into the new layer.
+    /// `alpha` is the group constant alpha applied at composite time; `mask` is an
+    /// optional ExtGState /SMask, pre-multiplied into the group before compositing.
     PushBlend {
         mode: BlendMode,
+        alpha: f32,
         clips: Vec<ClipStamp>,
+        mask: Option<MaskOps>,
     },
     /// End the current group: composite it onto the parent with `mode` (carried by
     /// the matching PushBlend), then re-stamp `clips` into the resulting layer.
@@ -139,6 +153,18 @@ impl PageRecorder {
     /// is the correct "clip to nothing" behavior).
     pub fn push_clip(&mut self, path: &DlPath, rule: FillRule, map: &PageMap) {
         let range = fill_mesh(path, rule, [0.0; 4], map).map(|m| self.append(m));
+        self.push_clip_range(range);
+    }
+
+    /// Push a clip to a *stroked* path's outline (tessellated as a stroke mesh).
+    pub fn push_clip_stroke(&mut self, path: &DlPath, style: &StrokeStyle, map: &PageMap) {
+        let range = stroke_mesh(path, style, [0.0; 4], map).map(|m| self.append(m));
+        self.push_clip_range(range);
+    }
+
+    /// Common tail of the clip-push variants: stamp the (optional) mesh as a clip
+    /// path and advance the clip depth (an empty mesh still occupies a level).
+    fn push_clip_range(&mut self, range: Option<MeshRange>) {
         let ref_value = self.clip_depth;
         if let Some(r) = range {
             self.ops.push(PageOp::StampClip {
@@ -186,9 +212,30 @@ impl PageRecorder {
 
     /// Begin a transparency group. The active clips are captured so the group's
     /// fresh layer (and, on pop, the composited result) reproduce the same clip.
-    pub fn push_blend(&mut self, mode: BlendMode) {
+    pub fn push_blend(&mut self, mode: BlendMode, alpha: f32, mask: Option<MaskOps>) {
         let clips = self.active_clips();
-        self.ops.push(PageOp::PushBlend { mode, clips });
+        self.ops.push(PageOp::PushBlend {
+            mode,
+            alpha,
+            clips,
+            mask,
+        });
+    }
+
+    /// Record a sub-sequence (a soft mask's commands) into the SHARED geometry
+    /// arena, but collect its ops separately instead of appending them to the
+    /// page op list. Clip state is isolated so the mask's clip nesting cannot
+    /// leak into the page. Returns the mask's ops (which reference the shared
+    /// vertex/index buffers, replayed later into a mask layer).
+    pub fn record_subops(&mut self, f: impl FnOnce(&mut Self)) -> Vec<PageOp> {
+        let saved_ops = std::mem::take(&mut self.ops);
+        let saved_stack = std::mem::take(&mut self.clip_stack);
+        let saved_depth = std::mem::replace(&mut self.clip_depth, 0);
+        f(self);
+        let sub = std::mem::replace(&mut self.ops, saved_ops);
+        self.clip_stack = saved_stack;
+        self.clip_depth = saved_depth;
+        sub
     }
 
     pub fn pop_blend(&mut self) {

--- a/crates/zpdf-render-wgpu/src/shaders/composite.wgsl
+++ b/crates/zpdf-render-wgpu/src/shaders/composite.wgsl
@@ -11,6 +11,7 @@ struct Page {
 };
 struct ModeU {
     id: u32,
+    alpha: f32,  // group constant alpha (/ca), applied to the source contribution
 };
 
 @group(0) @binding(0) var<uniform> page: Page;
@@ -125,7 +126,9 @@ fn non_separable(cb: vec3<f32>, cs: vec3<f32>, m: u32) -> vec3<f32> {
 @fragment
 fn fs_composite(in: VsOut) -> @location(0) vec4<f32> {
     let coord = vec2<i32>(i32(in.clip_pos.x), i32(in.clip_pos.y));
-    let s = textureLoad(group_tex, coord, 0); // source (premultiplied)
+    // Source (premultiplied) scaled by the group constant alpha: scaling
+    // premultiplied RGBA uniformly is exactly compositing the group at opacity α.
+    let s = textureLoad(group_tex, coord, 0) * mode.alpha;
     let d = textureLoad(base_tex, coord, 0);  // backdrop (premultiplied)
 
     let as_ = s.a;

--- a/crates/zpdf-render-wgpu/src/shaders/mask_apply.wgsl
+++ b/crates/zpdf-render-wgpu/src/shaders/mask_apply.wgsl
@@ -1,0 +1,62 @@
+// Soft-mask apply: pre-multiply a transparency group's resolved layer by the
+// per-pixel coverage of an ExtGState /SMask before it is composited. Coverage is
+// the mask group's luminosity (over the /BC backdrop baked into the mask layer
+// clear) for a luminosity mask, or its alpha for an alpha mask. Drawn as a
+// fullscreen quad into a fresh scratch layer (a pass cannot sample its target).
+
+struct Page {
+    w_px: f32,
+    h_px: f32,
+    scale: f32,
+    page_height: f32,
+};
+struct MaskU {
+    kind: u32, // 1 = luminosity, 2 = alpha
+};
+
+@group(0) @binding(0) var<uniform> page: Page;
+@group(1) @binding(0) var group_tex: texture_2d<f32>;
+@group(1) @binding(1) var mask_tex: texture_2d<f32>;
+@group(1) @binding(2) var<uniform> mu: MaskU;
+
+struct VsIn {
+    @location(0) pos: vec2<f32>,
+    @location(1) color: vec4<f32>,
+};
+struct VsOut {
+    @builtin(position) clip_pos: vec4<f32>,
+};
+
+@vertex
+fn vs_mask(in: VsIn) -> VsOut {
+    var out: VsOut;
+    out.clip_pos = vec4<f32>(2.0 * in.pos.x / page.w_px - 1.0, 1.0 - 2.0 * in.pos.y / page.h_px, 0.0, 1.0);
+    return out;
+}
+
+fn lum(c: vec3<f32>) -> f32 {
+    return dot(c, vec3<f32>(0.3, 0.59, 0.11));
+}
+
+@fragment
+fn fs_mask(in: VsOut) -> @location(0) vec4<f32> {
+    let coord = vec2<i32>(i32(in.clip_pos.x), i32(in.clip_pos.y));
+    let g = textureLoad(group_tex, coord, 0); // group (premultiplied)
+    let m = textureLoad(mask_tex, coord, 0);  // mask layer (premultiplied)
+
+    var cov: f32;
+    if (mu.kind == 1u) {
+        // Luminosity: the mask layer is opaque (cleared to /BC), so its straight
+        // colour equals its premultiplied colour; coverage = luminosity.
+        var rgb = m.rgb;
+        if (m.a > 0.0) {
+            rgb = m.rgb / m.a;
+        }
+        cov = clamp(lum(rgb), 0.0, 1.0);
+    } else {
+        cov = m.a; // alpha mask
+    }
+
+    // Scaling premultiplied RGBA by coverage applies the mask to the group.
+    return g * cov;
+}

--- a/crates/zpdf-render-wgpu/tests/blend.rs
+++ b/crates/zpdf-render-wgpu/tests/blend.rs
@@ -2,8 +2,11 @@
 //! PushBlendGroup ops, so we build DisplayLists programmatically and check the GPU
 //! layered path against (a) explicit blend math and (b) the CPU oracle.
 
+use std::sync::Arc;
 use zpdf_core::Rect;
-use zpdf_display_list::{BlendMode, Color, DisplayList, FillRule, Paint, Path, RenderCommand};
+use zpdf_display_list::{
+    BlendMode, Color, DisplayList, FillRule, Paint, Path, RenderCommand, SoftMask, SoftMaskKind,
+};
 use zpdf_render::RenderBackend;
 use zpdf_render_cpu::CpuRenderer;
 use zpdf_render_wgpu::WgpuRenderer;
@@ -92,6 +95,177 @@ fn normal_group_is_source_over() {
         right[0] > 200 && right[2] < 40,
         "right (normal) should be red, got {right:?}"
     );
+}
+
+/// A transparency group painted at group constant alpha 0.5 must match the CPU
+/// oracle (and read as ~50% red over the blue backdrop).
+#[test]
+fn group_alpha_matches_cpu_oracle() {
+    let mut dl = DisplayList::new(Rect::new(0.0, 0.0, W, H));
+    dl.push(fill(Color::rgb(0.0, 0.0, 1.0), (0.0, 0.0, W, H))); // blue base
+    dl.push(RenderCommand::PushBlendGroup {
+        blend_mode: BlendMode::Normal,
+        isolated: true,
+        knockout: false,
+        bounds: Rect::new(0.0, 0.0, W, H),
+        alpha: 0.5,
+        mask: None,
+    });
+    dl.push(fill(Color::rgb(1.0, 0.0, 0.0), (0.0, 0.0, W, H))); // red fill
+    dl.push(RenderCommand::PopBlendGroup);
+
+    let Some((gw, gh, gpu)) = gpu_render(&dl) else {
+        return;
+    };
+    let cpu = CpuRenderer::new()
+        .render_display_list(&dl, SCALE)
+        .expect("cpu render");
+    assert_eq!((gw, gh), (cpu.width, cpu.height));
+
+    // Center: 50% red over blue ≈ (128, 0, 128).
+    let c = px(&gpu, gw, gw / 2, gh / 2);
+    assert!(
+        c[0] > 100 && c[0] < 160 && c[1] < 40 && c[2] > 100 && c[2] < 160,
+        "group alpha 0.5: expected ~50% red over blue, got {c:?}"
+    );
+
+    let total = (gw * gh) as u64;
+    let mut diff = 0u64;
+    for i in 0..total as usize {
+        let b = i * 4;
+        let dr = (gpu[b] as i32 - cpu.data[b] as i32).unsigned_abs();
+        let dg = (gpu[b + 1] as i32 - cpu.data[b + 1] as i32).unsigned_abs();
+        let db = (gpu[b + 2] as i32 - cpu.data[b + 2] as i32).unsigned_abs();
+        if dr.max(dg).max(db) > 16 {
+            diff += 1;
+        }
+    }
+    let pct = diff as f64 / total as f64 * 100.0;
+    assert!(pct < 1.0, "group alpha: GPU vs CPU {pct:.3}% differing");
+}
+
+/// A luminosity soft mask (white left half over /BC=0) masks a red group: the
+/// red shows on the left (coverage 1) and the blue backdrop shows on the right
+/// (coverage 0). Must match the CPU oracle.
+#[test]
+fn luminosity_soft_mask_matches_cpu_oracle() {
+    let mut mask_dl = DisplayList::new(Rect::new(0.0, 0.0, W, H));
+    mask_dl.push(fill(Color::rgb(1.0, 1.0, 1.0), (0.0, 0.0, W / 2.0, H))); // white left half
+    let mask = SoftMask {
+        kind: SoftMaskKind::Luminosity,
+        commands: Arc::new(mask_dl),
+        offset: (0.0, 0.0),
+        backdrop_luma: 0.0,
+        transfer: None,
+    };
+
+    let mut dl = DisplayList::new(Rect::new(0.0, 0.0, W, H));
+    dl.push(fill(Color::rgb(0.0, 0.0, 1.0), (0.0, 0.0, W, H))); // blue base
+    dl.push(RenderCommand::PushBlendGroup {
+        blend_mode: BlendMode::Normal,
+        isolated: true,
+        knockout: false,
+        bounds: Rect::new(0.0, 0.0, W, H),
+        alpha: 1.0,
+        mask: Some(mask),
+    });
+    dl.push(fill(Color::rgb(1.0, 0.0, 0.0), (0.0, 0.0, W, H))); // red group
+    dl.push(RenderCommand::PopBlendGroup);
+
+    let Some((gw, gh, gpu)) = gpu_render(&dl) else {
+        return;
+    };
+    let cpu = CpuRenderer::new()
+        .render_display_list(&dl, SCALE)
+        .expect("cpu render");
+    assert_eq!((gw, gh), (cpu.width, cpu.height));
+
+    // Left: masked-in red; right: masked-out → blue backdrop.
+    let left = px(&gpu, gw, gw / 4, gh / 2);
+    let right = px(&gpu, gw, gw * 3 / 4, gh / 2);
+    assert!(
+        left[0] > 200 && left[2] < 50,
+        "mask left should be red, got {left:?}"
+    );
+    assert!(
+        right[2] > 200 && right[0] < 50,
+        "mask right should be blue (masked out), got {right:?}"
+    );
+
+    let total = (gw * gh) as u64;
+    let mut diff = 0u64;
+    for i in 0..total as usize {
+        let b = i * 4;
+        let dr = (gpu[b] as i32 - cpu.data[b] as i32).unsigned_abs();
+        let dg = (gpu[b + 1] as i32 - cpu.data[b + 1] as i32).unsigned_abs();
+        let db = (gpu[b + 2] as i32 - cpu.data[b + 2] as i32).unsigned_abs();
+        if dr.max(dg).max(db) > 16 {
+            diff += 1;
+        }
+    }
+    let pct = diff as f64 / total as f64 * 100.0;
+    assert!(pct < 1.0, "luminosity mask: GPU vs CPU {pct:.3}% differing");
+}
+
+/// An alpha soft mask (opaque left half) masks a red group by the mask group's
+/// alpha: red shows on the left, the backdrop on the right. Matches CPU.
+#[test]
+fn alpha_soft_mask_matches_cpu_oracle() {
+    let mut mask_dl = DisplayList::new(Rect::new(0.0, 0.0, W, H));
+    mask_dl.push(fill(Color::rgb(0.0, 1.0, 0.0), (0.0, 0.0, W / 2.0, H))); // opaque left half
+    let mask = SoftMask {
+        kind: SoftMaskKind::Alpha,
+        commands: Arc::new(mask_dl),
+        offset: (0.0, 0.0),
+        backdrop_luma: 0.0,
+        transfer: None,
+    };
+
+    let mut dl = DisplayList::new(Rect::new(0.0, 0.0, W, H));
+    dl.push(fill(Color::rgb(0.0, 0.0, 1.0), (0.0, 0.0, W, H))); // blue base
+    dl.push(RenderCommand::PushBlendGroup {
+        blend_mode: BlendMode::Normal,
+        isolated: true,
+        knockout: false,
+        bounds: Rect::new(0.0, 0.0, W, H),
+        alpha: 1.0,
+        mask: Some(mask),
+    });
+    dl.push(fill(Color::rgb(1.0, 0.0, 0.0), (0.0, 0.0, W, H))); // red group
+    dl.push(RenderCommand::PopBlendGroup);
+
+    let Some((gw, gh, gpu)) = gpu_render(&dl) else {
+        return;
+    };
+    let cpu = CpuRenderer::new()
+        .render_display_list(&dl, SCALE)
+        .expect("cpu render");
+
+    let left = px(&gpu, gw, gw / 4, gh / 2);
+    let right = px(&gpu, gw, gw * 3 / 4, gh / 2);
+    assert!(
+        left[0] > 200 && left[2] < 50,
+        "alpha mask left red: {left:?}"
+    );
+    assert!(
+        right[2] > 200 && right[0] < 50,
+        "alpha mask right blue: {right:?}"
+    );
+
+    let total = (gw * gh) as u64;
+    let mut diff = 0u64;
+    for i in 0..total as usize {
+        let b = i * 4;
+        let d = (gpu[b] as i32 - cpu.data[b] as i32)
+            .unsigned_abs()
+            .max((gpu[b + 1] as i32 - cpu.data[b + 1] as i32).unsigned_abs())
+            .max((gpu[b + 2] as i32 - cpu.data[b + 2] as i32).unsigned_abs());
+        if d > 16 {
+            diff += 1;
+        }
+    }
+    let pct = diff as f64 / total as f64 * 100.0;
+    assert!(pct < 1.0, "alpha mask: GPU vs CPU {pct:.3}% differing");
 }
 
 #[test]

--- a/crates/zpdf/tests/pattern_tiling.rs
+++ b/crates/zpdf/tests/pattern_tiling.rs
@@ -197,6 +197,46 @@ fn tiling_cell_oc_leak_does_not_suppress_page() {
     );
 }
 
+/// A tiling pattern applied to a STROKE paints the pattern clipped to the
+/// stroke outline (not a solid average colour, and not the path interior).
+/// Cell paints red in the left half (cell-x 0..10), white in the right half,
+/// so a position landing in the red sub-cell proves the real pattern is used.
+#[test]
+fn tiling_pattern_strokes_outline() {
+    // Red left half of a 20×20 cell; the right half shows the backdrop.
+    let cell: &[u8] = b"1 0 0 rg 0 0 10 20 re f";
+    let pat = "/Type /Pattern /PatternType 1 /PaintType 1 /TilingType 1 \
+               /BBox [0 0 20 20] /XStep 20 /YStep 20 /Resources << >>";
+    // 20pt-wide horizontal stroke along y=100 from x=20 to x=180. The stroke
+    // colour space/pattern use the uppercase (stroking) operators.
+    let content: &[u8] = b"/Pattern CS /P0 SCN 20 w 20 100 m 180 100 l S";
+    let pdf = assemble(&[
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R \
+          /Resources << /Pattern << /P0 5 0 R >> >> >>"
+            .to_vec(),
+        stream_obj("", content),
+        stream_obj(pat, cell),
+    ]);
+    let page = render(pdf);
+
+    // On the stroke band (y∈[90,110]) at x=45 → cell-x 5 → red sub-cell.
+    assert_rgbish(
+        px(&page, 45.0, 100.0),
+        [255, 0, 0],
+        "pattern on stroke (red)",
+    );
+    // On the stroke at x=55 → cell-x 15 → white sub-cell (NOT the solid avg).
+    assert_rgbish(
+        px(&page, 55.0, 100.0),
+        [255, 255, 255],
+        "pattern on stroke (white sub-cell)",
+    );
+    // Off the stroke (y=140) the pattern must not paint, even at a red cell-x.
+    assert_rgbish(px(&page, 45.0, 140.0), [255, 255, 255], "off-stroke clip");
+}
+
 /// A pattern /Matrix offsets the tiling grid: shifting the pattern by (10, 10)
 /// moves the red square from cell-space [2,9]² to page [12,19]².
 #[test]

--- a/crates/zpdf/tests/soft_mask.rs
+++ b/crates/zpdf/tests/soft_mask.rs
@@ -147,3 +147,83 @@ fn transparency_group_composites_with_group_alpha() {
     // Outside: untouched white.
     assert_near(px(&page, 180.0, 180.0), [255, 255, 255], 6, "background");
 }
+
+/// Knockout group (/K true): two overlapping 50%-alpha black squares. Each
+/// element composites against the group's (transparent) initial backdrop, so
+/// the overlap shows a single 50% black (≈127 gray), NOT the stacked 75%-black
+/// (≈64) a non-knockout group would accumulate.
+#[test]
+fn knockout_group_elements_do_not_accumulate() {
+    // Inside the group, GS1 sets fill alpha 0.5 for both squares.
+    let form: &[u8] = b"/GS1 gs 0 0 0 rg 20 20 100 100 re f 60 60 100 100 re f";
+    let content: &[u8] = b"/Fm0 Do";
+    let pdf = assemble(&[
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R \
+          /Resources << /XObject << /Fm0 5 0 R >> >> >>"
+            .to_vec(),
+        stream_obj("", content),
+        stream_obj(
+            "/Type /XObject /Subtype /Form /BBox [0 0 200 200] \
+             /Group << /S /Transparency /CS /DeviceRGB /I true /K true >> \
+             /Resources << /ExtGState << /GS1 6 0 R >> >>",
+            form,
+        ),
+        b"<< /Type /ExtGState /ca 0.5 >>".to_vec(),
+    ]);
+    let page = render(pdf);
+
+    // Square 1 only (40,40): 50% black over white ≈ 127.
+    assert_near(px(&page, 40.0, 40.0), [127, 127, 127], 16, "square 1 only");
+    // Square 2 only (140,140): also ≈ 127.
+    assert_near(
+        px(&page, 140.0, 140.0),
+        [127, 127, 127],
+        16,
+        "square 2 only",
+    );
+    // Overlap (80,80): knockout → still ≈ 127, NOT ≈ 64 (stacked).
+    assert_near(
+        px(&page, 80.0, 80.0),
+        [127, 127, 127],
+        16,
+        "knockout overlap",
+    );
+    // Background untouched.
+    assert_near(px(&page, 185.0, 185.0), [255, 255, 255], 6, "background");
+}
+
+/// Non-isolated group (/I false): a Multiply fill inside the group sees the
+/// page backdrop through the group, so gray × red = dark red. An isolated group
+/// would multiply against transparent and show plain gray instead.
+#[test]
+fn non_isolated_group_blends_with_backdrop() {
+    // Group form: a Multiply (GS0) 50% gray fill over the same area.
+    let form: &[u8] = b"/GS0 gs 0.5 0.5 0.5 rg 40 40 120 120 re f";
+    // Page: red backdrop, then the non-isolated group on top.
+    let content: &[u8] = b"1 0 0 rg 40 40 120 120 re f /Fm0 Do";
+    let pdf = assemble(&[
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R \
+          /Resources << /XObject << /Fm0 5 0 R >> >> >>"
+            .to_vec(),
+        stream_obj("", content),
+        stream_obj(
+            "/Type /XObject /Subtype /Form /BBox [0 0 200 200] \
+             /Group << /S /Transparency /CS /DeviceRGB /I false >> \
+             /Resources << /ExtGState << /GS0 6 0 R >> >>",
+            form,
+        ),
+        b"<< /Type /ExtGState /BM /Multiply >>".to_vec(),
+    ]);
+    let page = render(pdf);
+
+    // Center: gray × red = dark red (R kept, G/B knocked to ~0).
+    let c = px(&page, 100.0, 100.0);
+    assert!(
+        c[0] > 100 && c[1] < 60 && c[2] < 60,
+        "non-isolated multiply should be dark red, got {c:?}"
+    );
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -65,6 +65,57 @@ harness: `tests/corpus_run.sh`).
   per mask identity and derives offset uses by a shift-blit. Pixel-exact on
   the corpus shape, ~25× faster.
 
+### Closing the 0.4.0 known-limitations list
+
+The 0.4.0 "known limitations" are now implemented (all but legacy predefined
+CMap data tables, intentionally deferred), still with zero C/C++ dependencies.
+
+- **Transparency groups** (`zpdf-render-cpu`): knockout groups (`/K true`) now
+  composite each element against the group's *initial* backdrop instead of the
+  accumulation of preceding elements — a per-element pass captures the element's
+  *shape* (a full-opacity render) so a semi-transparent solid fill still fully
+  knocks out (PDF 11.4.9). Non-isolated groups (`/I false`) with no group-level
+  effect now render their elements straight onto the backdrop (the only correct
+  realization that lets element blend modes inside see it); a non-isolated group
+  carrying a constant alpha / soft mask / non-Normal group blend is still
+  approximated as isolated. A single object carrying a blend mode / soft mask is
+  treated as an isolated one-element group (was incidentally non-isolated).
+- **Pattern paints on strokes and text** (`zpdf-display-list`, `zpdf-content`,
+  `zpdf-render-cpu`, `zpdf-render-wgpu`): a tiling/shading pattern selected for a
+  stroke now clips the pattern to the stroke outline (new `PushClipStroke`
+  command; the CPU backend lifts a stroke-coverage mask, the GPU backend stamps
+  the stroke tessellation into the clip stencil) instead of stroking a solid
+  average colour. Text filled (or "stroked", render modes 1–6) with a pattern
+  clips the pattern to the glyph outlines (built from the font program) instead
+  of painting solid.
+- **`/RenderingIntent`** (`zpdf-color`, `zpdf-content`, `zpdf-image`): the `ri`
+  operator, ExtGState `/RI`, and image `/Intent` are parsed into the graphics
+  state and threaded through `IccTransform`/`IccCache` (now keyed by intent) to
+  the `moxcms` rendering intent — perceptual / relative- & absolute-colorimetric
+  / saturation, with the ICC-mandated fallback order.
+- **Per-CID vertical metrics `/W2`** (`zpdf-font`, `zpdf-document`,
+  `zpdf-content`): the `/W2` array (list and range forms) is parsed into per-CID
+  `(w1y, vx, vy)` triples and used for vertical writing-mode glyph placement,
+  overriding the `/DW2` default per glyph.
+- **JPX embedded ICC** (`zpdf-image`): an ICC profile carried inside a JPEG 2000
+  codestream is now compiled and applied (media-relative colorimetric) instead
+  of falling back to the channel count, when no PDF-level `/ColorSpace` overrides.
+- **JBIG2 advanced segments** (`zpdf-parser`): generic refinement regions
+  (type 22, GRTEMPLATE, TPGRON), symbol/aggregate refinement (`SDREFAGG`) and
+  text-region per-instance refinement (`SBREFINE`), Huffman coding (standard
+  tables B.1–B.15 + custom type-53 tables; Huffman symbol dictionaries and text
+  regions, types 40–43), and pattern dictionaries (16) + halftone regions (20)
+  now decode instead of rendering blank — round-trip-tested with new encoder
+  helpers. (Multi-plane MMR halftones remain lightly tested; arithmetic is the
+  common case.)
+- **wgpu soft masks + group alpha** (`zpdf-render-wgpu`): the GPU backend now
+  applies a group's constant alpha at composite time and rasterizes an ExtGState
+  `/SMask` into an offscreen coverage layer (luminosity over `/BC`, or group
+  alpha), pre-multiplying it into the group before compositing — validated
+  pixel-for-pixel against the CPU oracle. Residual: the `/TR` transfer function,
+  the tiling `offset`, nested groups inside a mask, and the `/RenderingIntent`
+  for codestream-ICC JPX are not yet honored on every path.
+
 ## 0.4.0 — closing the 0.3.0 gaps
 
 Every item on the 0.3.0 "known limitations" list is now implemented, still


### PR DESCRIPTION
Implements the remaining 0.4.0 "known limitations" (all but the deferred legacy predefined-CMap data tables), still zero C/C++ deps; 406 tests pass.

- Transparency groups (CPU): per-element knockout via a shape pass (PDF 11.4.9); non-isolated groups render elements onto the backdrop (passthrough), isolated-approx for group-level alpha/mask/non-Normal blend.
- Pattern paints on strokes (new PushClipStroke) and on text (glyph-outline clip) in both backends, instead of a solid approximation.
- /RenderingIntent: ri / ExtGState /RI / image /Intent threaded through IccTransform + IccCache (now keyed by intent) to moxcms.
- Per-CID vertical metrics /W2.
- JPX embedded ICC profiles applied (media-relative colorimetric).
- JBIG2 refinement, Huffman, pattern-dictionary + halftone segments decode.
- wgpu: group constant alpha + soft masks (luminosity/alpha) via an offscreen coverage layer, validated against the CPU oracle.

Tooling:
- Add .githooks/pre-commit (cargo fmt --all --check + clippy -D warnings), mirroring CI; activate with `git config core.hooksPath .githooks`.
- rustfmt: reflow two pre-existing method chains for rustfmt 1.9.0.