### PR TITLE
fix(linearize): main xref must cover the objects the first-page table does not

### DIFF
--- a/crates/zpdf-writer/src/linearize.rs
+++ b/crates/zpdf-writer/src/linearize.rs
@@ -178,15 +178,35 @@ pub fn linearize_pdf(source: &PdfFile) -> Result<Vec<u8>> {
         emit(&mut out, num, obj)?;
     }
 
-    // (6) Main xref: object 0 free + objects 1 (lin dict) and 2 (hint stream).
+    // (6) Main xref: object 0 (free) plus every object the first-page table
+    // does *not* cover.
+    //
+    // Annex F splits the cross-reference in two: the table at the top covers
+    // the first-page section (objects 1, 2 and the first-page set), and this
+    // one covers the remainder. Emitting objects 1 and 2 again here left
+    // every object after the first-page set — 11..25 on a four-page file —
+    // present in the body and absent from *both* tables, so `/Size` was 3
+    // while 25 objects existed. Readers that trust the table then fail:
+    // `MuPDF: object out of range (11 0 R); xref size 11`, three of four
+    // pages dangling, `qpdf --check-linearization` reporting `/N does not
+    // match number of pages`.
     let main_xref_ofs = out.len() as u64;
+    let first_rest_num = 3 + first_objs.len() as u32;
     let mut main_xref = String::new();
-    main_xref.push_str("xref\n0 3\n");
-    main_xref.push_str("0000000000 65535 f \n");
-    main_xref.push_str(&format!("{lin_ofs:010} 00000 n \n"));
-    main_xref.push_str(&format!("{hint_ofs:010} 00000 n \n"));
+    main_xref.push_str("xref\n0 1\n0000000000 65535 f \n");
+    if !rest_objs.is_empty() {
+        main_xref.push_str(&format!("{} {}\n", first_rest_num, rest_objs.len()));
+        for id in &rest_objs {
+            let num = number[id];
+            main_xref.push_str(&format!("{:010} 00000 n \n", offsets[&num]));
+        }
+    }
+    // /Size is the total object count, and /Root belongs here too: a reader
+    // that starts from the main xref (rather than following /Prev from the
+    // first) has no other way to find the catalog.
     main_xref.push_str(&format!(
-        "trailer\n<< /Size 3 >>\nstartxref\n{first_xref_ofs}\n%%EOF\n"
+        "trailer\n<< /Size {} /Root {} 0 R >>\nstartxref\n{first_xref_ofs}\n%%EOF\n",
+        total_objects, number[&root]
     ));
     out.extend_from_slice(main_xref.as_bytes());
     let total_len = out.len() as u64; // /L

--- a/crates/zpdf-writer/tests/linearize.rs
+++ b/crates/zpdf-writer/tests/linearize.rs
@@ -1,0 +1,141 @@
+//! Linearization: the cross-reference tables must cover every object.
+//!
+//! Why this file exists: the in-module test asserts that the output parses
+//! and declares `/Linearized`, and it passed while the output was badly
+//! malformed — because `zpdf-parser` repairs a broken cross-reference table
+//! by scanning for objects, so zpdf reading its own output papers over
+//! exactly the defect under test. Any check that routes through our own
+//! parser is therefore blind here; these assertions read the raw bytes.
+//!
+//! The defect this pins: the main table emitted `xref 0 3` (object 0 free,
+//! then the linearization dict and hint stream — objects the *first-page*
+//! table already covers) and `/Size 3`, so every object after the first-page
+//! section existed in the body and in no table at all. On a four-page file
+//! objects 11..25 were unreachable: `qpdf --check-linearization` reported
+//! `/N does not match number of pages`, MuPDF reported `object out of range
+//! (11 0 R); xref size 11`, and three of the four pages dangled.
+
+use std::collections::HashSet;
+
+use zpdf_writer::linearize_pdf;
+
+/// A document with enough objects that the first-page section cannot cover
+/// them all — the whole point is to have a "rest" section.
+fn multipage_source() -> Vec<u8> {
+    let mut b = zpdf_writer::builder::DocumentBuilder::new();
+    for i in 0..4 {
+        let p = b.add_page(612.0, 792.0);
+        b.add_text(
+            p,
+            &format!("page {}", i + 1),
+            50.0,
+            700.0,
+            "Helvetica",
+            12.0,
+            (0.0, 0.0, 0.0),
+        )
+        .unwrap();
+    }
+    b.build().unwrap()
+}
+
+/// Object numbers that appear as `N 0 obj` in the body.
+fn body_objects(bytes: &[u8]) -> HashSet<u32> {
+    let text = String::from_utf8_lossy(bytes);
+    let mut out = HashSet::new();
+    for line in text.lines() {
+        let mut it = line.split_whitespace();
+        if let (Some(n), Some("0"), Some("obj")) = (it.next(), it.next(), it.next()) {
+            if let Ok(num) = n.parse::<u32>() {
+                out.insert(num);
+            }
+        }
+    }
+    out
+}
+
+/// Object numbers covered by any `xref` subsection header in the file.
+fn xref_covered(bytes: &[u8]) -> HashSet<u32> {
+    let text = String::from_utf8_lossy(bytes);
+    let mut out = HashSet::new();
+    let mut lines = text.lines().peekable();
+    while let Some(line) = lines.next() {
+        if line.trim() != "xref" {
+            continue;
+        }
+        // Subsection headers are `start count`; entries are 20 bytes each.
+        while let Some(peek) = lines.peek() {
+            let parts: Vec<&str> = peek.split_whitespace().collect();
+            if parts.len() == 2 {
+                if let (Ok(start), Ok(count)) = (parts[0].parse::<u32>(), parts[1].parse::<u32>()) {
+                    lines.next();
+                    for k in 0..count {
+                        out.insert(start + k);
+                        lines.next(); // the entry line
+                    }
+                    continue;
+                }
+            }
+            break;
+        }
+    }
+    out
+}
+
+fn trailer_size(bytes: &[u8]) -> Option<u32> {
+    let text = String::from_utf8_lossy(bytes);
+    let i = text.rfind("/Size")?;
+    text[i + 5..]
+        .split_whitespace()
+        .next()?
+        .trim_end_matches(|c: char| !c.is_ascii_digit())
+        .parse()
+        .ok()
+}
+
+#[test]
+fn every_body_object_is_covered_by_a_cross_reference_table() {
+    let out = linearize_pdf(&zpdf_parser::PdfFile::parse(multipage_source()).unwrap()).unwrap();
+    let body = body_objects(&out);
+    let covered = xref_covered(&out);
+    assert!(!body.is_empty(), "no objects were written at all");
+    let missing: Vec<u32> = {
+        let mut v: Vec<u32> = body.difference(&covered).copied().collect();
+        v.sort_unstable();
+        v
+    };
+    assert!(
+        missing.is_empty(),
+        "objects exist in the body but in no xref table: {missing:?} \
+         (body={} objects, covered={} entries)",
+        body.len(),
+        covered.len(),
+    );
+}
+
+#[test]
+fn trailer_size_matches_the_highest_object_number() {
+    let out = linearize_pdf(&zpdf_parser::PdfFile::parse(multipage_source()).unwrap()).unwrap();
+    let highest = *body_objects(&out).iter().max().unwrap();
+    let size = trailer_size(&out).expect("no /Size in any trailer");
+    assert_eq!(
+        size,
+        highest + 1,
+        "/Size must be one more than the highest object number \
+         (qpdf: \"reported number of objects is not one plus the highest object number\")"
+    );
+}
+
+#[test]
+fn the_main_trailer_names_the_catalog() {
+    // A reader that starts from the main table rather than following /Prev
+    // from the first-page one has no other way to find /Root.
+    let out = linearize_pdf(&zpdf_parser::PdfFile::parse(multipage_source()).unwrap()).unwrap();
+    let text = String::from_utf8_lossy(&out);
+    let main_trailer = text.rfind("trailer").expect("no trailer");
+    assert!(
+        text[main_trailer..].contains("/Root"),
+        "the last trailer must carry /Root: {}",
+        &text[main_trailer..(main_trailer + 80).min(text.len())]
+    );
+}


### PR DESCRIPTION
## The defect

`linearize_pdf` emits the **main** cross-reference table as:

```
xref
0 3
0000000000 65535 f 
<lin dict offset> 00000 n 
<hint stream offset> 00000 n 
trailer
<< /Size 3 >>
```

Those are object 0, the linearization dictionary (1) and the hint stream (2) —
but objects 1 and 2 are already covered by the *first-page* table at the top of
the file. Annex F splits the cross-reference the other way round: the table at
the front covers the first-page section, and the main table at the end covers
the remainder.

The result is that every object after the first-page section is written into
the body and appears in **no** table. On a four-page document (objects 1..25),
objects 11..25 are unreachable:

```
$ qpdf --check-linearization lin.pdf
WARNING: lin.pdf: error encountered while checking linearization data:
  lin.pdf (linearization dictionary, offset 1176): /N does not match number of pages

$ qpdf --check lin.pdf
WARNING: lin.pdf: reported number of objects (26) is not one plus the highest
  object number (10)
Pages tree includes non-dictionary object; ignoring      # ×3

# MuPDF (PyMuPDF 1.x)
MuPDF error: format error: object out of range (11 0 R); xref size 11   # ×hundreds
MuPDF error: format error: non-page object in page tree
```

Three of the four pages dangle — only page 1, whose objects the first-page
table does cover, resolves.

Reproduced identically on three different inputs: a MuPDF-authored file, the
same file normalised with `qpdf --object-streams=disable`, and the output of
`rewrite_pdf` — so it is independent of input shape, and of whether the
document was garbage-collected first.

## The fix

Emit object 0 plus the objects the first-page table does not cover, set
`/Size` to the total object count, and include `/Root` in the main trailer —
a reader that starts from the main table, rather than following `/Prev` from
the first-page one, has no other way to find the catalog.

After the change, on the same fixture:

```
$ qpdf --check lin.pdf
File is linearized                      # no structural errors
$ python -c "import pikepdf; print(pikepdf.open('lin.pdf').is_linearized)"
True
```

MuPDF and poppler extract text identical to the source file.

One warning remains and is **unrelated** to this change: `qpdf` reports
`overflow reading bit stream: wanted = 32; available = 0`, because the hint
stream is a placeholder rather than real page-offset hint tables. The module
documentation already says so, and hints are advisory, so I have left that
alone rather than widen the scope of the PR.

## Why the existing test did not catch it

`linearized_output_parses_and_declares_linearization` asserts that the output
parses and declares `/Linearized`, and it passes against the malformed file —
because `zpdf-parser` repairs a damaged cross-reference table by scanning for
objects. The library therefore hides this defect from itself, and any check
that routes through it is blind here.

So the added `crates/zpdf-writer/tests/linearize.rs` reads the raw bytes
instead:

* every `N 0 obj` in the body is covered by some `xref` subsection;
* `/Size` equals the highest object number plus one;
* the last trailer carries `/Root`.

All three fail on `main` and pass with this change. It is also the integration
test this feature was missing — every other writer feature (`annotate`,
`builder`, `encrypt`, `incremental`, `merge`, `redact`, `rewrite`, `sign`) has
one.

## Context

Found while evaluating zpdf for a desktop document tool that needs
user-password decryption and xref repair. Both of those work well —
`crypt.rs`'s AES-256 R6 path (Algorithm 2.A/2.B) verified against files
encrypted by qpdf, and the parser recovered a 4-page file byte-identically
from a bogus `startxref`, a truncated tail with no trailer at all, and a
corrupted offset. Thanks for the crate.
