### PR TITLE
fix(document): resolve indirect /W width sub-arrays in CIDFonts

### DIFF
--- a/crates/zpdf-document/src/font_loader.rs
+++ b/crates/zpdf-document/src/font_loader.rs
@@ -767,7 +767,20 @@ fn parse_cid_widths(file: &PdfFile, dict: &zpdf_core::PdfDict) -> CidWidths {
             break;
         }
 
-        match &w_array[i] {
+        // In the `[cid [w1 w2 ...]]` form the width sub-array is frequently an
+        // *indirect* reference (AutoCAD/nanoCAD export /W this way). Resolve one
+        // level so the `PdfObject::Array` arm below sees it; otherwise the entry
+        // fell through to `_ => i += 1`, the sub-array was skipped, and every CID
+        // in the range silently defaulted to /DW — breaking advances (and thus
+        // inter-glyph spacing), so the text drifts.
+        let resolved = if let PdfObject::Ref(id) = &w_array[i] {
+            file.resolve(*id).ok()
+        } else {
+            None
+        };
+        let entry = resolved.as_ref().unwrap_or(&w_array[i]);
+
+        match entry {
             PdfObject::Array(arr) => {
                 // [cid_start [w1 w2 w3 ...]]
                 for (j, obj) in arr.iter().enumerate() {
@@ -785,7 +798,7 @@ fn parse_cid_widths(file: &PdfFile, dict: &zpdf_core::PdfDict) -> CidWidths {
             }
             PdfObject::Integer(_) | PdfObject::Real(_) => {
                 // [cid_start cid_end width]
-                let cid_end = w_array[i]
+                let cid_end = entry
                     .as_i64()
                     .ok()
                     .and_then(|v| u16::try_from(v).ok())

--- a/crates/zpdf-document/tests/font_loader_indirect.rs
+++ b/crates/zpdf-document/tests/font_loader_indirect.rs
@@ -191,3 +191,35 @@ fn type3_indirect_refs_resolve() {
     assert_eq!(font.type3_glyph_width(65), 500.0);
     assert_eq!(font.type3_glyph_width(66), 600.0);
 }
+
+#[test]
+fn cid_w_indirect_width_subarray_resolves() {
+    // A /W entry's width sub-array `[w1 w2 ...]` is often an INDIRECT reference
+    // (AutoCAD/nanoCAD export). Without resolving it the entry is skipped and
+    // every CID falls back to /DW — advances (and inter-glyph spacing) break, so
+    // text drifts. Here CIDs 10,11,12 must pick up 111,222,333, not /DW 1000.
+    let pdf = build_pdf(&[
+        dict_obj("<< /Type /Catalog >>"),
+        dict_obj(
+            "<< /Type /Font /Subtype /Type0 /BaseFont /T /Encoding /Identity-H \
+             /DescendantFonts [3 0 R] >>",
+        ),
+        dict_obj(
+            "<< /Type /Font /Subtype /CIDFontType2 /BaseFont /T /FontDescriptor 4 0 R \
+             /CIDToGIDMap /Identity /DW 1000 /W [ 10 5 0 R ] >>",
+        ),
+        dict_obj("<< /Type /FontDescriptor /FontName /T /Flags 4 >>"),
+        dict_obj("[ 111 222 333 ]"),
+    ]);
+
+    let file = PdfFile::parse(pdf).expect("parse synthetic pdf");
+    let font = load_single_font(&file, ObjectId(2, 0)).expect("load font");
+    assert_eq!(font.cid_widths.get(10), 111.0);
+    assert_eq!(font.cid_widths.get(11), 222.0);
+    assert_eq!(font.cid_widths.get(12), 333.0);
+    assert_eq!(
+        font.cid_widths.get_opt(9),
+        None,
+        "CIDs outside /W keep /DW (not set)"
+    );
+}


### PR DESCRIPTION
## Problem
A CIDFont's `/W` array may use the `[cid [w1 w2 ...]]` form where the width sub-array is an **indirect reference** rather than a literal array. ISO 32000-1 (9.7.4.3) allows any array element to be an indirect object, and AutoCAD / nanoCAD routinely export `/W` this way:

```
/W [ 1 20 0 R ]        % 20 0 obj  [500 500 600 ...]
```

## Root cause
`parse_cid_widths` (`crates/zpdf-document/src/font_loader.rs`) matched `&w_array[i]` directly. A `PdfObject::Ref` sub-array therefore fell through to the `_ => i += 1` arm: the whole run was skipped and every CID in it silently defaulted to `/DW`. The result is wrong glyph advances and broken inter-glyph spacing -- text visibly drifts/overlaps for such fonts.

## Fix
Resolve one level of indirection before matching the entry (the same treatment `resolve_array` already gives an indirect `/W` array itself). Literal sub-arrays are unaffected.

## Test
`cid_w_indirect_width_subarray_resolves` builds a synthetic Type0 font whose `/W` sub-array is an indirect object and asserts the CIDs pick up their real widths (111/222/333) instead of `/DW` (1000).