### PR TITLE
fix(document): accept inline /FontDescriptor and /DescendantFonts CID dicts

### DIFF
--- a/crates/zpdf-document/src/font_loader.rs
+++ b/crates/zpdf-document/src/font_loader.rs
@@ -76,19 +76,17 @@ fn substitute_hints(
     dict: &zpdf_core::PdfDict,
 ) -> zpdf_font::system::SubstituteHints {
     let mut hints = zpdf_font::system::SubstituteHints::default();
-    if let Ok(fd_ref) = dict.get_ref("FontDescriptor") {
-        if let Ok(fd) = file.resolve(fd_ref) {
-            if let Ok(fd) = fd.as_dict() {
-                if let Ok(flags) = fd.get_i64("Flags") {
-                    hints.fixed_pitch = flags & 1 != 0;
-                    hints.serif = flags & 2 != 0;
-                    hints.italic = flags & 64 != 0;
-                    hints.bold = flags & (1 << 18) != 0; // ForceBold
-                }
-                if let Ok(w) = fd.get_f64("StemV") {
-                    hints.bold |= w >= 160.0;
-                }
-            }
+    // /FontDescriptor must be indirect per spec, but AutoCAD and other producers
+    // inline it; resolve_dict accepts both forms.
+    if let Some(fd) = resolve_dict(file, dict, "FontDescriptor") {
+        if let Ok(flags) = fd.get_i64("Flags") {
+            hints.fixed_pitch = flags & 1 != 0;
+            hints.serif = flags & 2 != 0;
+            hints.italic = flags & 64 != 0;
+            hints.bold = flags & (1 << 18) != 0; // ForceBold
+        }
+        if let Ok(w) = fd.get_f64("StemV") {
+            hints.bold |= w >= 160.0;
         }
     }
     hints
@@ -185,14 +183,8 @@ fn builtin_symbol_encoding(base_font: &str) -> Option<zpdf_font::encoding::Encod
 /// Read the FontDescriptor /Flags and decide whether the font is symbolic
 /// (bit 3 set, bit 6 clear).
 fn font_descriptor_symbolic(file: &PdfFile, dict: &zpdf_core::PdfDict) -> bool {
-    let fd_ref = match dict.get_ref("FontDescriptor") {
-        Ok(r) => r,
-        Err(_) => return false,
-    };
-    let flags = file
-        .resolve(fd_ref)
-        .ok()
-        .and_then(|o| o.as_dict().ok().and_then(|d| d.get_i64("Flags").ok()));
+    let flags =
+        resolve_dict(file, dict, "FontDescriptor").and_then(|d| d.get_i64("Flags").ok());
     matches!(flags, Some(f) if (f & 4) != 0 && (f & 32) == 0)
 }
 
@@ -202,13 +194,22 @@ fn font_descriptor_symbolic(file: &PdfFile, dict: &zpdf_core::PdfDict) -> bool {
 fn font_descriptor_dict(file: &PdfFile, dict: &zpdf_core::PdfDict) -> Option<zpdf_core::PdfDict> {
     let host = if dict.get_name("Subtype").unwrap_or("") == "Type0" {
         let descendants = resolve_array(file, dict, "DescendantFonts")?;
-        let desc_ref = descendants.first()?.as_ref().ok()?;
-        file.resolve(desc_ref).ok()?.as_dict().ok()?.clone()
+        descendant_cid_dict(file, &descendants)?
     } else {
         dict.clone()
     };
-    let fd_ref = host.get_ref("FontDescriptor").ok()?;
-    file.resolve(fd_ref).ok()?.as_dict().ok().cloned()
+    resolve_dict(file, &host, "FontDescriptor")
+}
+
+/// The first /DescendantFonts entry as a dict. The spec requires an indirect
+/// reference, but AutoCAD and other producers inline the CIDFont dict directly
+/// in the array; accept both forms.
+fn descendant_cid_dict(file: &PdfFile, descendants: &[PdfObject]) -> Option<zpdf_core::PdfDict> {
+    match descendants.first()? {
+        PdfObject::Dict(d) => Some(d.clone()),
+        PdfObject::Ref(r) => file.resolve(*r).ok()?.as_dict().ok().cloned(),
+        _ => None,
+    }
 }
 
 /// Map a `/FontStretch` name to its OpenType `wdth`-axis percentage (Table 122).
@@ -366,13 +367,11 @@ fn load_type0_font(
     // /DescendantFonts is commonly an indirect reference to the array.
     let descendants = resolve_array(file, dict, "DescendantFonts")
         .ok_or_else(|| zpdf_core::Error::MissingKey("DescendantFonts".into()))?;
-    let desc_ref = descendants
-        .first()
-        .ok_or_else(|| zpdf_core::Error::MissingKey("DescendantFonts[0]".into()))?
-        .as_ref()?;
-
-    let desc_obj = file.resolve(desc_ref)?;
-    let desc_dict = desc_obj.as_dict()?;
+    // /DescendantFonts is commonly an indirect reference to the array; the
+    // CIDFont entry itself may also be inlined (AutoCAD) instead of a ref.
+    let desc_dict = descendant_cid_dict(file, &descendants)
+        .ok_or_else(|| zpdf_core::Error::MissingKey("DescendantFonts[0]".into()))?;
+    let desc_dict = &desc_dict;
 
     let mut cid_widths = parse_cid_widths(file, desc_dict);
     parse_cid_w2(file, desc_dict, &mut cid_widths);
@@ -677,9 +676,7 @@ fn load_type1_font(
 
 /// Extract embedded font binary from FontDescriptor → FontFile2 (TrueType).
 fn extract_font_file(file: &PdfFile, cid_dict: &zpdf_core::PdfDict) -> Option<Vec<u8>> {
-    let fd_ref = cid_dict.get_ref("FontDescriptor").ok()?;
-    let fd_obj = file.resolve(fd_ref).ok()?;
-    let fd_dict = fd_obj.as_dict().ok()?;
+    let fd_dict = resolve_dict(file, cid_dict, "FontDescriptor")?;
 
     // Try FontFile2 (TrueType), then FontFile3 (OpenType/CFF), then FontFile (Type1)
     for key in &["FontFile2", "FontFile3", "FontFile"] {
@@ -698,9 +695,7 @@ fn extract_font_file_from_descriptor(
     file: &PdfFile,
     font_dict: &zpdf_core::PdfDict,
 ) -> Option<Vec<u8>> {
-    let fd_ref = font_dict.get_ref("FontDescriptor").ok()?;
-    let fd_obj = file.resolve(fd_ref).ok()?;
-    let fd_dict = fd_obj.as_dict().ok()?;
+    let fd_dict = resolve_dict(file, font_dict, "FontDescriptor")?;
 
     for key in &["FontFile2", "FontFile3", "FontFile"] {
         if let Ok(ff_ref) = fd_dict.get_ref(key) {

--- a/crates/zpdf-document/tests/font_loader_indirect.rs
+++ b/crates/zpdf-document/tests/font_loader_indirect.rs
@@ -191,3 +191,55 @@ fn type3_indirect_refs_resolve() {
     assert_eq!(font.type3_glyph_width(65), 500.0);
     assert_eq!(font.type3_glyph_width(66), 600.0);
 }
+
+#[test]
+fn inline_font_descriptor_resolves() {
+    // AutoCAD (and other producers) emit the CIDFont's /FontDescriptor as an
+    // INLINE dict, though ISO 32000 requires an indirect reference. A
+    // spec-strict, `get_ref`-only read finds no descriptor, so the embedded
+    // /FontFile is never extracted and the font falls back to a substitute.
+    // `resolve_dict` accepts both forms; the embedded program must attach.
+    let pdf = build_pdf(&[
+        dict_obj("<< /Type /Catalog >>"),
+        dict_obj(
+            "<< /Type /Font /Subtype /Type0 /BaseFont /T /Encoding /Identity-H \
+             /DescendantFonts [3 0 R] >>",
+        ),
+        dict_obj(
+            "<< /Type /Font /Subtype /CIDFontType0 /BaseFont /T /CIDToGIDMap /Identity /DW 1000 \
+             /FontDescriptor << /Type /FontDescriptor /FontName /T /Flags 4 /FontFile3 4 0 R >> >>",
+        ),
+        stream_obj(&cid_keyed_cff()),
+    ]);
+
+    let file = PdfFile::parse(pdf).expect("parse synthetic pdf");
+    let font = load_single_font(&file, ObjectId(2, 0)).expect("load font");
+    assert!(
+        font.has_font_data(),
+        "inline /FontDescriptor resolved and /FontFile3 program parsed"
+    );
+}
+
+#[test]
+fn inline_descendant_cidfont_resolves() {
+    // The /DescendantFonts entry itself may be an inline CIDFont dict rather
+    // than an indirect reference (AutoCAD). The descendant's embedded font
+    // program must still load.
+    let pdf = build_pdf(&[
+        dict_obj("<< /Type /Catalog >>"),
+        dict_obj(
+            "<< /Type /Font /Subtype /Type0 /BaseFont /T /Encoding /Identity-H \
+             /DescendantFonts [ << /Type /Font /Subtype /CIDFontType0 /BaseFont /T \
+             /CIDToGIDMap /Identity /DW 1000 /FontDescriptor 3 0 R >> ] >>",
+        ),
+        dict_obj("<< /Type /FontDescriptor /FontName /T /Flags 4 /FontFile3 4 0 R >>"),
+        stream_obj(&cid_keyed_cff()),
+    ]);
+
+    let file = PdfFile::parse(pdf).expect("parse synthetic pdf");
+    let font = load_single_font(&file, ObjectId(2, 0)).expect("load font");
+    assert!(
+        font.has_font_data(),
+        "inline /DescendantFonts CIDFont dict resolved and program loaded"
+    );
+}


### PR DESCRIPTION
## Problem
ISO 32000 requires a font's `/FontDescriptor` (and the `/DescendantFonts` CIDFont entry of a Type0 font) to be **indirect references**. AutoCAD, nanoCAD and other CAD producers routinely emit them **inline** as direct dictionaries:

```
/DescendantFonts [ << /Subtype /CIDFontType2 ... /FontDescriptor << ... /FontFile2 9 0 R >> >> ]
```

## Root cause
`crates/zpdf-document/src/font_loader.rs` read these strictly with `get_ref(...)` / `.as_ref()`. For an inline dict those return `Err`/`None`, so:
- the descriptor was not found, the embedded `/FontFile*` was never extracted, and the font silently degraded to a **system substitute** (wrong metrics/outlines), or
- `load_type0_font` failed to find the descendant CIDFont at all.

## Fix
- Route every `/FontDescriptor` lookup through the existing `resolve_dict` helper (already used for `/Encoding` and `/CharProcs`), which accepts both a direct dict and an indirect ref.
- Add a small `descendant_cid_dict` helper that accepts an inline CIDFont dict **or** an indirect ref as the first `/DescendantFonts` element.

No behavior change for spec-compliant (indirect) fonts.

## Tests
- `inline_font_descriptor_resolves` - Type0 font with an **inline** `/FontDescriptor`; asserts the embedded CFF program is extracted (`has_font_data()`).
- `inline_descendant_cidfont_resolves` - Type0 font whose `/DescendantFonts[0]` is an **inline** CIDFont dict; same assertion.