### PR TITLE
feat(content): support text render modes 4-7 (text clipping)

### DIFF
--- a/crates/zpdf-content/src/interpreter.rs
+++ b/crates/zpdf-content/src/interpreter.rs
@@ -25,6 +25,13 @@ pub struct ContentInterpreter<'a> {
     text_active: bool,
     text_matrix: Matrix,
     text_line_matrix: Matrix,
+    /// Page-space accumulator for text clipping (render modes 4–7): every glyph
+    /// shown in the current BT…ET block appends its outline here, and `ET`
+    /// intersects the union into the clip stack (see `apply_text_clip`). `None` =
+    /// no glyph outlines accumulated yet. `text_clip_requested` records that a
+    /// clip render mode was seen at all, even if no drawable glyph produced one.
+    text_clip_accum: Option<Path>,
+    text_clip_requested: bool,
     font_cache: Option<&'a mut FontCache>,
     current_font_id: Option<zpdf_font::FontId>,
     file: Option<&'a PdfFile>,
@@ -471,6 +478,8 @@ impl<'a> ContentInterpreter<'a> {
             text_active: false,
             text_matrix: Matrix::identity(),
             text_line_matrix: Matrix::identity(),
+            text_clip_accum: None,
+            text_clip_requested: false,
             font_cache: None,
             current_font_id: None,
             file: None,
@@ -1164,9 +1173,12 @@ impl<'a> ContentInterpreter<'a> {
                 self.text_active = true;
                 self.text_matrix = Matrix::identity();
                 self.text_line_matrix = Matrix::identity();
+                self.text_clip_accum = None;
+                self.text_clip_requested = false;
             }
             "ET" => {
                 self.text_active = false;
+                self.apply_text_clip();
             }
             "Tf" => {
                 let size = self.pop_f64() as f32;
@@ -4559,6 +4571,26 @@ impl<'a> ContentInterpreter<'a> {
             _ => cs_produces_no_marks(&self.current.fill_cs),
         };
         let invisible = matches!(self.current.render_mode, 3 | 7) || no_marks;
+        // Text render modes 4–7 also *add the glyph outlines to the clipping
+        // path* (applied at ET). Accumulate them in page space now — regardless
+        // of whether the run is also painted (4=fill+clip, 5=stroke+clip,
+        // 6=fill+stroke+clip, 7=clip only). Without this, a following opaque fill
+        // or image meant to show only through the glyphs paints over everything.
+        if matches!(self.current.render_mode, 4..=7) {
+            self.text_clip_requested = true;
+            if let Some((_, font)) = font_and_id {
+                if !glyphs.is_empty() {
+                    if let Some((clip_path, _)) =
+                        build_glyph_clip_path(&glyphs, &combined, font, font_size, h_scale)
+                    {
+                        match self.text_clip_accum.as_mut() {
+                            Some(accum) => accum.elements.extend(clip_path.elements),
+                            None => self.text_clip_accum = Some(clip_path),
+                        }
+                    }
+                }
+            }
+        }
         if let Some(font_id) = self.current_font_id {
             if !glyphs.is_empty() && !invisible {
                 // A Pattern colour space on the active paint (fill for modes
@@ -4609,6 +4641,33 @@ impl<'a> ContentInterpreter<'a> {
             Matrix::translate(x_offset as f64, 0.0)
         };
         self.text_matrix = self.text_matrix.concat(&advance);
+    }
+
+    /// At `ET`, fold any text-clip accumulated during the block (render modes
+    /// 4–7) into the clip stack. The glyph outlines are already in page space,
+    /// so this mirrors a `W n` clip: push a NonZero `PushClip` and bump
+    /// `clip_depth` so the enclosing `Q` pops it. Without this, a subsequent
+    /// opaque fill or image meant to show only through the glyph shapes paints
+    /// over the whole surrounding clip region.
+    ///
+    /// A clip mode that produced no drawable glyphs (bare font, Type3, empty
+    /// run) leaves nothing to clip to; we skip pushing rather than emit an empty
+    /// path (which the renderer treats as "no clip", not "clip everything out"),
+    /// preserving the prior behaviour for that rare case.
+    fn apply_text_clip(&mut self) {
+        if !self.text_clip_requested {
+            return;
+        }
+        self.text_clip_requested = false;
+        let Some(path) = self.text_clip_accum.take().filter(|p| !p.is_empty()) else {
+            return;
+        };
+        self.intersect_clip_bounds(Self::path_bounds(&path));
+        self.display_list.push(RenderCommand::PushClip {
+            path,
+            rule: FillRule::NonZero,
+        });
+        self.current.clip_depth += 1;
     }
 
     fn adjust_text_position(&mut self, amount: f64) {
@@ -5106,6 +5165,102 @@ mod tests {
         let page_rect = Rect::new(0.0, 0.0, 612.0, 792.0);
         let dl = ContentInterpreter::new(page_rect).interpret(content);
         assert_eq!(dl.commands.len(), 2);
+    }
+
+    // ---- Text clipping (render modes 4–7) ----
+
+    fn hex_bytes(s: &str) -> Vec<u8> {
+        (0..s.len())
+            .step_by(2)
+            .map(|i| u8::from_str_radix(&s[i..i + 2], 16).unwrap())
+            .collect()
+    }
+
+    // A minimal 8-glyph TrueType font carrying real contours for glyphs 3..=6,
+    // used as an Identity-CID composite so `<0003>` etc. resolve to those GIDs.
+    const FONT_PRESENT_HEX: &str = concat!(
+        "00010000000a0080000300204f532f32412841d30000012800000060636d6170000c008a0000019c00000034676c7966",
+        "9c789c74000001e400000068686561642e66b048000000ac000000366868656104b2025a000000e400000024686d7478",
+        "0258000000000188000000126c6f636100680071000001d0000000126d617870000a000600000108000000206e616d65",
+        "00995cc80000024c0000003c706f7374d625404700000288000000470001000000010000d0fc3df65f0f3cf5000103e8",
+        "00000000e67d365600000000e67d36560064000001f402bc000000030002000000000000000100000320ff3800000258",
+        "000000c80190000100000000000000000000000000000001000100000008000400010000000000020000000000000000",
+        "000000000000000000030258019000050004000000000000000000000000000000000000000000000000000000000000",
+        "0000000000010000000000000000000000003f3f3f3f0000003100370000000000000000000000000000000000000000",
+        "000000000020000002580000000000000000000000000000000000000000000200000003000000140003000100000014",
+        "00040020000000040004000100000037ffff00000031ffffffd00001000000000000000000000000000d001a00270034",
+        "0034000000010064000001f402bc000300003311211164019002bcfd440000010064000001f402bc0003000033112111",
+        "64019002bcfd440000010064000001f402bc000300003311211164019002bcfd440000010064000001f402bc00030000",
+        "3311211164019002bcfd4400000000040036000100000000000100010000000100000000000200010001000300010409",
+        "000100020002000300010409000200020004545200540052000200000000000000000000000000000000000000000000",
+        "000000000000000000080000010201030104010501060107010802673102673202673302673402673502673602673700",
+    );
+
+    #[test]
+    fn text_clip_mode_confines_following_fill_to_glyphs() {
+        // PDF text render modes 4–7 add the shown glyph outlines to the clipping
+        // path, applied at ET. Without this a following opaque fill/image that
+        // was meant to appear only through the glyph shapes paints over the whole
+        // surrounding region. A `7 Tr` (clip-only) show followed by a
+        // page-covering fill inside one q…Q must therefore emit a text-clip
+        // PushClip before the fill (popped by the enclosing Q), while the
+        // clip-only text itself paints no visible glyph run.
+        let kinds = |content: &[u8]| -> Vec<&'static str> {
+            let mut fonts = FontCache::new();
+            let mut f = zpdf_font::LoadedFont::new_with_data(
+                zpdf_font::PdfFontType::Type0CidType2,
+                "Sub".into(),
+                hex_bytes(FONT_PRESENT_HEX),
+                zpdf_font::CidWidths::new(1000.0),
+            );
+            f.cid_cmap = Some(zpdf_font::cmap::CidCMap::identity(0));
+            fonts.insert("F".to_string(), f);
+            let dl = ContentInterpreter::new(Rect::new(0.0, 0.0, 612.0, 792.0))
+                .with_fonts(&mut fonts)
+                .interpret(content);
+            dl.commands
+                .iter()
+                .map(|c| match c {
+                    RenderCommand::PushClip { .. } => "push",
+                    RenderCommand::PopClip => "pop",
+                    RenderCommand::FillPath { .. } => "fill",
+                    RenderCommand::DrawGlyphRun(_) => "glyph",
+                    _ => "other",
+                })
+                .collect()
+        };
+
+        let clip_kinds =
+            kinds(b"q BT /F 40 Tf 7 Tr <0003000400050006> Tj ET 0 0 1000 1000 re f Q");
+        // Baseline: identical but ordinary fill text (mode 0) — no text clip.
+        let base_kinds =
+            kinds(b"q BT /F 40 Tf 0 Tr <0003000400050006> Tj ET 0 0 1000 1000 re f Q");
+
+        assert!(
+            !clip_kinds.contains(&"glyph"),
+            "mode-7 text paints nothing: {clip_kinds:?}"
+        );
+        assert!(
+            base_kinds.contains(&"glyph"),
+            "mode-0 text paints a glyph run: {base_kinds:?}"
+        );
+
+        let fi = clip_kinds.iter().position(|k| *k == "fill").expect("fill");
+        assert!(
+            clip_kinds[..fi].contains(&"push"),
+            "text clip pushed before the fill: {clip_kinds:?}"
+        );
+        let bfi = base_kinds.iter().position(|k| *k == "fill").expect("fill");
+        assert!(
+            !base_kinds[..bfi].contains(&"push"),
+            "no clip without a clip render mode: {base_kinds:?}"
+        );
+
+        assert_eq!(
+            clip_kinds.iter().filter(|k| **k == "push").count(),
+            clip_kinds.iter().filter(|k| **k == "pop").count(),
+            "clips balanced: {clip_kinds:?}"
+        );
     }
 
     // ---- Ruled-line capture (rule sink for table detection) ----


### PR DESCRIPTION
## Problem
PDF text render modes 4-7 (ISO 32000-1, Table 106) add the shown glyph outlines to the current **clipping path**, which takes effect at the next `ET`. The interpreter treated mode 7 purely as "invisible" and never accumulated the glyph outlines, so the text clip was never established.

The consequence is severe for a common CAD / vector-export idiom: a table or label is drawn as an opaque fill or image that is **pre-clipped to text** -- draw the digits/letters in mode 7, then paint an opaque rectangle or image so only the glyph-shaped area shows. With no text clip, that opaque paint covers the **whole surrounding region** and blanks the content beneath it. (Real-world symptom: entire image-backed tables rendering as blank white blocks.)

## Fix
Accumulate the glyph outlines (in page space, via the existing `build_glyph_clip_path`) for every show in modes 4-7 across a `BT...ET` block, and at `ET` fold their union into the clip stack as a NonZero `PushClip` -- exactly like a `W n` clip, popped by the enclosing `Q`. Modes 4/5/6 still paint (fill/stroke) in addition to clipping.

A clip mode that produces no drawable glyph outlines (bare/Type3 font, empty run) is left un-clipped rather than emitting an empty path -- the renderer treats an empty clip path as "no clip", not "clip everything out", so this preserves prior behaviour for that rare case.

## Test
`text_clip_mode_confines_following_fill_to_glyphs` shows clip-only (mode 7) text followed by a page-covering fill inside one `q...Q` and asserts a text-clip `PushClip` precedes the fill (balanced by a pop), while a mode-0 baseline emits no such clip; the clip-only run paints no visible glyph run. Uses a self-contained 8-glyph TrueType fixture so the glyph clip path is non-empty.