### PR TITLE
feat(content): add ContentInterpreter::with_content_translation

### DIFF
--- a/crates/zpdf-content/src/interpreter.rs
+++ b/crates/zpdf-content/src/interpreter.rs
@@ -650,6 +650,18 @@ impl<'a> ContentInterpreter<'a> {
         self
     }
 
+    /// Translate the initial CTM by `(dx, dy)`, exactly as a leading
+    /// `1 0 0 1 dx dy cm` operator would (concatenated onto the current CTM,
+    /// leaving `base_ctm` untouched). This lets a caller apply a CropBox-origin
+    /// shift — e.g. AutoCAD pages whose content lives at a non-zero MediaBox/
+    /// CropBox origin — without prepending that operator to a *copy* of the whole
+    /// content stream (on a 20+ MB stream that duplicate is pure waste). Call
+    /// after [`with_page_rotation`](Self::with_page_rotation).
+    pub fn with_content_translation(mut self, dx: f64, dy: f64) -> Self {
+        self.current.ctm = self.current.ctm.concat(&Matrix::translate(dx, dy));
+        self
+    }
+
     pub fn with_fonts(mut self, cache: &'a mut FontCache) -> Self {
         self.font_cache = Some(cache);
         self
@@ -5106,6 +5118,37 @@ mod tests {
         let page_rect = Rect::new(0.0, 0.0, 612.0, 792.0);
         let dl = ContentInterpreter::new(page_rect).interpret(content);
         assert_eq!(dl.commands.len(), 2);
+    }
+
+    #[test]
+    fn with_content_translation_shifts_emitted_geometry() {
+        // with_content_translation applies a (dx, dy) shift as the initial CTM,
+        // exactly like a leading `1 0 0 1 dx dy cm`, without prepending that
+        // operator to a copy of the whole content stream. Emitted geometry must
+        // move by exactly (dx, dy) versus an untranslated interpret.
+        let content = b"10 20 5 5 re f";
+        let page = Rect::new(0.0, 0.0, 100.0, 100.0);
+        let first_move = |dl: &DisplayList| -> (f64, f64) {
+            for c in &dl.commands {
+                if let RenderCommand::FillPath { path, .. } = c {
+                    if let Some(PathElement::MoveTo(p)) = path.elements.first() {
+                        return (p.x, p.y);
+                    }
+                }
+            }
+            panic!("no fill emitted");
+        };
+        let base = first_move(&ContentInterpreter::new(page).interpret(content));
+        let shifted = first_move(
+            &ContentInterpreter::new(page)
+                .with_content_translation(100.0, 200.0)
+                .interpret(content),
+        );
+        assert!(
+            (shifted.0 - (base.0 + 100.0)).abs() < 1e-6
+                && (shifted.1 - (base.1 + 200.0)).abs() < 1e-6,
+            "content shifted by exactly (100, 200): base={base:?} shifted={shifted:?}"
+        );
     }
 
     // ---- Ruled-line capture (rule sink for table detection) ----


### PR DESCRIPTION
## Motivation
Pages whose content lives at a non-zero MediaBox/CropBox origin -- common in AutoCAD exports, and when compositing a rotated page -- need a CropBox-origin shift applied to the content.

The only way to apply such a shift previously was to prepend a `1 0 0 1 dx dy cm` operator to the content stream, which forces copying the **entire** content stream first. On large CAD streams (20+ MB) that duplicate is pure waste.

## Change
Add a small builder `ContentInterpreter::with_content_translation(dx, dy)` that concatenates `Matrix::translate(dx, dy)` onto the current CTM (leaving `base_ctm` untouched) -- exactly equivalent to a leading `cm`, but with no stream copy. Intended to be called after `with_page_rotation`.

## Test
`with_content_translation_shifts_emitted_geometry` asserts a filled rectangle's emitted page-space geometry moves by exactly `(dx, dy)` versus an untranslated interpret.
