### PR TITLE
fix(content): key form-XObject fonts by object id to avoid sibling collisions

### DIFF
--- a/crates/zpdf-content/src/interpreter.rs
+++ b/crates/zpdf-content/src/interpreter.rs
@@ -3615,39 +3615,37 @@ impl<'a> ContentInterpreter<'a> {
 
             match obj {
                 PdfObject::Ref(font_ref) => {
-                    let page_has_same_name = page_font_ids.contains_key(&name.0);
-                    let page_has_same_obj = page_font_ids
+                    // If the page already caches this exact font under this same
+                    // name, the plain name already resolves to it — no override.
+                    let page_same_obj = page_font_ids
                         .get(&name.0)
                         .map(|id| *id == *font_ref)
                         .unwrap_or(false);
-
-                    if page_has_same_name && page_has_same_obj {
+                    if page_same_obj {
                         continue;
                     }
 
-                    if page_has_same_name && !page_has_same_obj {
-                        let unique_name = format!("__form{}_{}", form_depth, name.0);
-                        if fc.get_by_name(&unique_name).is_none() {
-                            if let Err(e) = load_into(fc, &unique_name) {
-                                tracing::debug!("form font {}: {e}", name.0);
-                                let _ = fc.try_insert_with_limit(
-                                    unique_name.clone(),
-                                    zpdf_font::LoadedFont::new_placeholder(name.0.clone()),
-                                    max_font_bytes,
-                                );
-                            }
-                        }
-                        overrides.insert(name.0.clone(), unique_name);
-                    } else if fc.get_by_name(&name.0).is_none() {
-                        if let Err(e) = load_into(fc, &name.0) {
+                    // Otherwise scope the cache slot by the font's object id.
+                    // Sibling form XObjects routinely reuse the same resource
+                    // name for *different* fonts (ArchiCAD/GraphiSoft emit /R7,
+                    // /R9 in every form). Keying the shared cache by name — even
+                    // by (form-depth, name) — collides for two siblings at the
+                    // same depth: the first-loaded font won and every later
+                    // form's text rendered with the wrong subset. An object-id
+                    // key also dedupes a font shared across forms (loaded once,
+                    // reused).
+                    let unique_name = format!("__font_{}_{}", font_ref.0, font_ref.1);
+                    if fc.get_by_name(&unique_name).is_none() {
+                        if let Err(e) = load_into(fc, &unique_name) {
                             tracing::debug!("form font {}: {e}", name.0);
                             let _ = fc.try_insert_with_limit(
-                                name.0.clone(),
+                                unique_name.clone(),
                                 zpdf_font::LoadedFont::new_placeholder(name.0.clone()),
                                 max_font_bytes,
                             );
                         }
                     }
+                    overrides.insert(name.0.clone(), unique_name);
                 }
                 PdfObject::Dict(_) => {
                     // Inline font dict: rename to avoid clobbering a same-named

--- a/crates/zpdf-content/tests/form_font_object_id.rs
+++ b/crates/zpdf-content/tests/form_font_object_id.rs
@@ -1,0 +1,101 @@
+//! Two sibling form XObjects that reuse the same font resource name (`/R7`) for
+//! *different* font objects must not collide in the shared FontCache. Keying by
+//! name (or by form-depth+name) let the first form's font win, so the second
+//! form's text rendered with the wrong subset. Keying by the font's object id
+//! gives each distinct font its own cache slot.
+
+use zpdf_content::interpreter::ContentInterpreter;
+use zpdf_core::Rect;
+use zpdf_document::PdfDocument;
+use zpdf_font::FontCache;
+
+/// Page invokes two forms; each form's /Resources/Font maps the *same* name
+/// `/R7` to a *different* font object (7 vs 8). The page itself declares no
+/// fonts. `load_form_fonts` loads every font a form references when the form is
+/// invoked, so the form bodies can be empty.
+fn build_pdf() -> Vec<u8> {
+    let content: &[u8] = b"/Fm1 Do /Fm2 Do";
+    let form_body: &[u8] = b""; // no marks needed; fonts load on invocation
+
+    let form = |font_obj: u32| -> Vec<u8> {
+        let mut v = format!(
+            "<< /Type /XObject /Subtype /Form /BBox [0 0 100 100] \
+             /Resources << /Font << /R7 {font_obj} 0 R >> >> /Length {} >>\nstream\n",
+            form_body.len()
+        )
+        .into_bytes();
+        v.extend_from_slice(form_body);
+        v.extend_from_slice(b"\nendstream");
+        v
+    };
+
+    let objs: Vec<(u32, Vec<u8>)> = vec![
+        (1, b"<< /Type /Catalog /Pages 2 0 R >>".to_vec()),
+        (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec()),
+        (
+            3,
+            b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] \
+              /Resources << /XObject << /Fm1 5 0 R /Fm2 6 0 R >> >> /Contents 4 0 R >>"
+                .to_vec(),
+        ),
+        (4, {
+            let mut v = format!("<< /Length {} >>\nstream\n", content.len()).into_bytes();
+            v.extend_from_slice(content);
+            v.extend_from_slice(b"\nendstream");
+            v
+        }),
+        (5, form(7)),
+        (6, form(8)),
+        (7, b"<< /Type /Font /Subtype /Type1 /BaseFont /FontA >>".to_vec()),
+        (8, b"<< /Type /Font /Subtype /Type1 /BaseFont /FontB >>".to_vec()),
+    ];
+
+    let mut out = b"%PDF-1.4\n".to_vec();
+    let mut offsets = Vec::new();
+    for (num, body) in &objs {
+        offsets.push(out.len());
+        out.extend_from_slice(format!("{num} 0 obj\n").as_bytes());
+        out.extend_from_slice(body);
+        out.extend_from_slice(b"\nendobj\n");
+    }
+    let xref_off = out.len();
+    out.extend_from_slice(format!("xref\n0 {}\n", objs.len() + 1).as_bytes());
+    out.extend_from_slice(b"0000000000 65535 f \n");
+    for off in &offsets {
+        out.extend_from_slice(format!("{off:010} 00000 n \n").as_bytes());
+    }
+    out.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF",
+            objs.len() + 1,
+            xref_off
+        )
+        .as_bytes(),
+    );
+    out
+}
+
+#[test]
+fn sibling_forms_reusing_a_font_name_get_distinct_cache_slots() {
+    let doc = PdfDocument::open(build_pdf()).expect("parse synthetic PDF");
+    let page = doc.page(0).expect("page 0");
+    let content = doc.page_content_bytes(&page).expect("content");
+
+    // The page declares no fonts, so every FontCache entry after interpret comes
+    // from the two forms. Whether the font dicts load or fall back to a
+    // placeholder, each form contributes exactly one entry under its object-id
+    // key — so two distinct font objects yield two entries. Keying by name would
+    // give one (the second form reusing the first's slot).
+    let mut cache = FontCache::new();
+    let _ = ContentInterpreter::new(Rect::new(0.0, 0.0, 200.0, 200.0))
+        .with_fonts(&mut cache)
+        .with_document(doc.file(), &page.resources)
+        .interpret(&content);
+
+    assert_eq!(
+        cache.len(),
+        2,
+        "two sibling forms reusing /R7 for different font objects must occupy \
+         two cache slots, not collide into one"
+    );
+}


### PR DESCRIPTION
## Problem
Sibling form XObjects routinely reuse the same font resource name (e.g. `/R7`, `/R9`) for **different** font objects -- ArchiCAD / GraphiSoft emit them in every form. `load_form_fonts` keyed the shared `FontCache` by name (`__form{depth}_{name}`), which still collides for two siblings at the same form depth:

- form 1's `/R7` (object 7) is loaded under `__form0_R7`;
- form 2's `/R7` (object 8) sees `__form0_R7` already present and **skips loading**, so form 2's text renders with form 1's (wrong) subset.

## Fix
Key the cache slot by the font's **object id** (`__font_{obj}_{gen}`). Each distinct font object gets its own slot, and a font genuinely shared across forms is loaded once and reused. Inline (non-reference) form fonts, which have no object id, keep the previous depth+name scheme.

## Test
`tests/form_font_object_id.rs`: a page invokes two forms whose `/Font` both map `/R7` to different font objects (7 vs 8); after interpret the `FontCache` holds **two** entries. I verified it fails on `main` (`left: 1, right: 2`) and passes with the fix.

## Testing notes (please read)
This is an **integration test** that drives the whole path -- `PdfDocument::open` on a synthetic PDF, `execute_do` -> `do_form_xobject` -> `load_form_fonts` -- and asserts on `FontCache::len()`. It is deterministic here (the two font dicts each contribute exactly one cache entry whether they load or fall back to a placeholder, so the count is robust to font-loading outcome and needs no system fonts). But it is coupled to a few implementation assumptions -- that a form loads its `/Font` resources on invocation even with an empty body, and that a load failure still inserts a placeholder entry -- so it could become a false pass or break if those change. If you'd prefer a narrower assertion (e.g. exposing the override map, or checking the two glyph runs' font ids via embedded fonts), I'm happy to adjust.
