### PR TITLE
fix: integrate reviewed compatibility and rendering PRs

### DIFF
--- a/crates/zpdf-content/src/interpreter.rs
+++ b/crates/zpdf-content/src/interpreter.rs
@@ -650,6 +650,18 @@ impl<'a> ContentInterpreter<'a> {
         self
     }
 
+    /// Translate the initial CTM by `(dx, dy)`, exactly as a leading
+    /// `1 0 0 1 dx dy cm` operator would (concatenated onto the current CTM,
+    /// leaving `base_ctm` untouched). This lets a caller apply a CropBox-origin
+    /// shift — e.g. AutoCAD pages whose content lives at a non-zero MediaBox/
+    /// CropBox origin — without prepending that operator to a *copy* of the whole
+    /// content stream (on a 20+ MB stream that duplicate is pure waste). Call
+    /// after [`with_page_rotation`](Self::with_page_rotation).
+    pub fn with_content_translation(mut self, dx: f64, dy: f64) -> Self {
+        self.current.ctm = self.current.ctm.concat(&Matrix::translate(dx, dy));
+        self
+    }
+
     pub fn with_fonts(mut self, cache: &'a mut FontCache) -> Self {
         self.font_cache = Some(cache);
         self
@@ -5106,6 +5118,37 @@ mod tests {
         let page_rect = Rect::new(0.0, 0.0, 612.0, 792.0);
         let dl = ContentInterpreter::new(page_rect).interpret(content);
         assert_eq!(dl.commands.len(), 2);
+    }
+
+    #[test]
+    fn with_content_translation_shifts_emitted_geometry() {
+        // with_content_translation applies a (dx, dy) shift as the initial CTM,
+        // exactly like a leading `1 0 0 1 dx dy cm`, without prepending that
+        // operator to a copy of the whole content stream. Emitted geometry must
+        // move by exactly (dx, dy) versus an untranslated interpret.
+        let content = b"10 20 5 5 re f";
+        let page = Rect::new(0.0, 0.0, 100.0, 100.0);
+        let first_move = |dl: &DisplayList| -> (f64, f64) {
+            for c in &dl.commands {
+                if let RenderCommand::FillPath { path, .. } = c {
+                    if let Some(PathElement::MoveTo(p)) = path.elements.first() {
+                        return (p.x, p.y);
+                    }
+                }
+            }
+            panic!("no fill emitted");
+        };
+        let base = first_move(&ContentInterpreter::new(page).interpret(content));
+        let shifted = first_move(
+            &ContentInterpreter::new(page)
+                .with_content_translation(100.0, 200.0)
+                .interpret(content),
+        );
+        assert!(
+            (shifted.0 - (base.0 + 100.0)).abs() < 1e-6
+                && (shifted.1 - (base.1 + 200.0)).abs() < 1e-6,
+            "content shifted by exactly (100, 200): base={base:?} shifted={shifted:?}"
+        );
     }
 
     // ---- Ruled-line capture (rule sink for table detection) ----

--- a/crates/zpdf-content/src/interpreter.rs
+++ b/crates/zpdf-content/src/interpreter.rs
@@ -3615,39 +3615,37 @@ impl<'a> ContentInterpreter<'a> {
 
             match obj {
                 PdfObject::Ref(font_ref) => {
-                    let page_has_same_name = page_font_ids.contains_key(&name.0);
-                    let page_has_same_obj = page_font_ids
+                    // If the page already caches this exact font under this same
+                    // name, the plain name already resolves to it — no override.
+                    let page_same_obj = page_font_ids
                         .get(&name.0)
                         .map(|id| *id == *font_ref)
                         .unwrap_or(false);
-
-                    if page_has_same_name && page_has_same_obj {
+                    if page_same_obj {
                         continue;
                     }
 
-                    if page_has_same_name && !page_has_same_obj {
-                        let unique_name = format!("__form{}_{}", form_depth, name.0);
-                        if fc.get_by_name(&unique_name).is_none() {
-                            if let Err(e) = load_into(fc, &unique_name) {
-                                tracing::debug!("form font {}: {e}", name.0);
-                                let _ = fc.try_insert_with_limit(
-                                    unique_name.clone(),
-                                    zpdf_font::LoadedFont::new_placeholder(name.0.clone()),
-                                    max_font_bytes,
-                                );
-                            }
-                        }
-                        overrides.insert(name.0.clone(), unique_name);
-                    } else if fc.get_by_name(&name.0).is_none() {
-                        if let Err(e) = load_into(fc, &name.0) {
+                    // Otherwise scope the cache slot by the font's object id.
+                    // Sibling form XObjects routinely reuse the same resource
+                    // name for *different* fonts (ArchiCAD/GraphiSoft emit /R7,
+                    // /R9 in every form). Keying the shared cache by name — even
+                    // by (form-depth, name) — collides for two siblings at the
+                    // same depth: the first-loaded font won and every later
+                    // form's text rendered with the wrong subset. An object-id
+                    // key also dedupes a font shared across forms (loaded once,
+                    // reused).
+                    let unique_name = format!("__font_{}_{}", font_ref.0, font_ref.1);
+                    if fc.get_by_name(&unique_name).is_none() {
+                        if let Err(e) = load_into(fc, &unique_name) {
                             tracing::debug!("form font {}: {e}", name.0);
                             let _ = fc.try_insert_with_limit(
-                                name.0.clone(),
+                                unique_name.clone(),
                                 zpdf_font::LoadedFont::new_placeholder(name.0.clone()),
                                 max_font_bytes,
                             );
                         }
                     }
+                    overrides.insert(name.0.clone(), unique_name);
                 }
                 PdfObject::Dict(_) => {
                     // Inline font dict: rename to avoid clobbering a same-named

--- a/crates/zpdf-content/src/interpreter.rs
+++ b/crates/zpdf-content/src/interpreter.rs
@@ -25,6 +25,13 @@ pub struct ContentInterpreter<'a> {
     text_active: bool,
     text_matrix: Matrix,
     text_line_matrix: Matrix,
+    /// Page-space accumulator for text clipping (render modes 4–7): every glyph
+    /// shown in the current BT…ET block appends its outline here, and `ET`
+    /// intersects the union into the clip stack (see `apply_text_clip`). `None` =
+    /// no glyph outlines accumulated yet. `text_clip_requested` records that a
+    /// clip render mode was seen at all, even if no drawable glyph produced one.
+    text_clip_accum: Option<Path>,
+    text_clip_requested: bool,
     font_cache: Option<&'a mut FontCache>,
     current_font_id: Option<zpdf_font::FontId>,
     file: Option<&'a PdfFile>,
@@ -471,6 +478,8 @@ impl<'a> ContentInterpreter<'a> {
             text_active: false,
             text_matrix: Matrix::identity(),
             text_line_matrix: Matrix::identity(),
+            text_clip_accum: None,
+            text_clip_requested: false,
             font_cache: None,
             current_font_id: None,
             file: None,
@@ -1164,9 +1173,12 @@ impl<'a> ContentInterpreter<'a> {
                 self.text_active = true;
                 self.text_matrix = Matrix::identity();
                 self.text_line_matrix = Matrix::identity();
+                self.text_clip_accum = None;
+                self.text_clip_requested = false;
             }
             "ET" => {
                 self.text_active = false;
+                self.apply_text_clip();
             }
             "Tf" => {
                 let size = self.pop_f64() as f32;
@@ -4559,6 +4571,26 @@ impl<'a> ContentInterpreter<'a> {
             _ => cs_produces_no_marks(&self.current.fill_cs),
         };
         let invisible = matches!(self.current.render_mode, 3 | 7) || no_marks;
+        // Text render modes 4–7 also *add the glyph outlines to the clipping
+        // path* (applied at ET). Accumulate them in page space now — regardless
+        // of whether the run is also painted (4=fill+clip, 5=stroke+clip,
+        // 6=fill+stroke+clip, 7=clip only). Without this, a following opaque fill
+        // or image meant to show only through the glyphs paints over everything.
+        if matches!(self.current.render_mode, 4..=7) {
+            self.text_clip_requested = true;
+            if let Some((_, font)) = font_and_id {
+                if !glyphs.is_empty() {
+                    if let Some((clip_path, _)) =
+                        build_glyph_clip_path(&glyphs, &combined, font, font_size, h_scale)
+                    {
+                        match self.text_clip_accum.as_mut() {
+                            Some(accum) => accum.elements.extend(clip_path.elements),
+                            None => self.text_clip_accum = Some(clip_path),
+                        }
+                    }
+                }
+            }
+        }
         if let Some(font_id) = self.current_font_id {
             if !glyphs.is_empty() && !invisible {
                 // A Pattern colour space on the active paint (fill for modes
@@ -4609,6 +4641,33 @@ impl<'a> ContentInterpreter<'a> {
             Matrix::translate(x_offset as f64, 0.0)
         };
         self.text_matrix = self.text_matrix.concat(&advance);
+    }
+
+    /// At `ET`, fold any text-clip accumulated during the block (render modes
+    /// 4–7) into the clip stack. The glyph outlines are already in page space,
+    /// so this mirrors a `W n` clip: push a NonZero `PushClip` and bump
+    /// `clip_depth` so the enclosing `Q` pops it. Without this, a subsequent
+    /// opaque fill or image meant to show only through the glyph shapes paints
+    /// over the whole surrounding clip region.
+    ///
+    /// A clip mode that produced no drawable glyphs (bare font, Type3, empty
+    /// run) leaves nothing to clip to; we skip pushing rather than emit an empty
+    /// path (which the renderer treats as "no clip", not "clip everything out"),
+    /// preserving the prior behaviour for that rare case.
+    fn apply_text_clip(&mut self) {
+        if !self.text_clip_requested {
+            return;
+        }
+        self.text_clip_requested = false;
+        let Some(path) = self.text_clip_accum.take().filter(|p| !p.is_empty()) else {
+            return;
+        };
+        self.intersect_clip_bounds(Self::path_bounds(&path));
+        self.display_list.push(RenderCommand::PushClip {
+            path,
+            rule: FillRule::NonZero,
+        });
+        self.current.clip_depth += 1;
     }
 
     fn adjust_text_position(&mut self, amount: f64) {
@@ -5106,6 +5165,102 @@ mod tests {
         let page_rect = Rect::new(0.0, 0.0, 612.0, 792.0);
         let dl = ContentInterpreter::new(page_rect).interpret(content);
         assert_eq!(dl.commands.len(), 2);
+    }
+
+    // ---- Text clipping (render modes 4–7) ----
+
+    fn hex_bytes(s: &str) -> Vec<u8> {
+        (0..s.len())
+            .step_by(2)
+            .map(|i| u8::from_str_radix(&s[i..i + 2], 16).unwrap())
+            .collect()
+    }
+
+    // A minimal 8-glyph TrueType font carrying real contours for glyphs 3..=6,
+    // used as an Identity-CID composite so `<0003>` etc. resolve to those GIDs.
+    const FONT_PRESENT_HEX: &str = concat!(
+        "00010000000a0080000300204f532f32412841d30000012800000060636d6170000c008a0000019c00000034676c7966",
+        "9c789c74000001e400000068686561642e66b048000000ac000000366868656104b2025a000000e400000024686d7478",
+        "0258000000000188000000126c6f636100680071000001d0000000126d617870000a000600000108000000206e616d65",
+        "00995cc80000024c0000003c706f7374d625404700000288000000470001000000010000d0fc3df65f0f3cf5000103e8",
+        "00000000e67d365600000000e67d36560064000001f402bc000000030002000000000000000100000320ff3800000258",
+        "000000c80190000100000000000000000000000000000001000100000008000400010000000000020000000000000000",
+        "000000000000000000030258019000050004000000000000000000000000000000000000000000000000000000000000",
+        "0000000000010000000000000000000000003f3f3f3f0000003100370000000000000000000000000000000000000000",
+        "000000000020000002580000000000000000000000000000000000000000000200000003000000140003000100000014",
+        "00040020000000040004000100000037ffff00000031ffffffd00001000000000000000000000000000d001a00270034",
+        "0034000000010064000001f402bc000300003311211164019002bcfd440000010064000001f402bc0003000033112111",
+        "64019002bcfd440000010064000001f402bc000300003311211164019002bcfd440000010064000001f402bc00030000",
+        "3311211164019002bcfd4400000000040036000100000000000100010000000100000000000200010001000300010409",
+        "000100020002000300010409000200020004545200540052000200000000000000000000000000000000000000000000",
+        "000000000000000000080000010201030104010501060107010802673102673202673302673402673502673602673700",
+    );
+
+    #[test]
+    fn text_clip_mode_confines_following_fill_to_glyphs() {
+        // PDF text render modes 4–7 add the shown glyph outlines to the clipping
+        // path, applied at ET. Without this a following opaque fill/image that
+        // was meant to appear only through the glyph shapes paints over the whole
+        // surrounding region. A `7 Tr` (clip-only) show followed by a
+        // page-covering fill inside one q…Q must therefore emit a text-clip
+        // PushClip before the fill (popped by the enclosing Q), while the
+        // clip-only text itself paints no visible glyph run.
+        let kinds = |content: &[u8]| -> Vec<&'static str> {
+            let mut fonts = FontCache::new();
+            let mut f = zpdf_font::LoadedFont::new_with_data(
+                zpdf_font::PdfFontType::Type0CidType2,
+                "Sub".into(),
+                hex_bytes(FONT_PRESENT_HEX),
+                zpdf_font::CidWidths::new(1000.0),
+            );
+            f.cid_cmap = Some(zpdf_font::cmap::CidCMap::identity(0));
+            fonts.insert("F".to_string(), f);
+            let dl = ContentInterpreter::new(Rect::new(0.0, 0.0, 612.0, 792.0))
+                .with_fonts(&mut fonts)
+                .interpret(content);
+            dl.commands
+                .iter()
+                .map(|c| match c {
+                    RenderCommand::PushClip { .. } => "push",
+                    RenderCommand::PopClip => "pop",
+                    RenderCommand::FillPath { .. } => "fill",
+                    RenderCommand::DrawGlyphRun(_) => "glyph",
+                    _ => "other",
+                })
+                .collect()
+        };
+
+        let clip_kinds =
+            kinds(b"q BT /F 40 Tf 7 Tr <0003000400050006> Tj ET 0 0 1000 1000 re f Q");
+        // Baseline: identical but ordinary fill text (mode 0) — no text clip.
+        let base_kinds =
+            kinds(b"q BT /F 40 Tf 0 Tr <0003000400050006> Tj ET 0 0 1000 1000 re f Q");
+
+        assert!(
+            !clip_kinds.contains(&"glyph"),
+            "mode-7 text paints nothing: {clip_kinds:?}"
+        );
+        assert!(
+            base_kinds.contains(&"glyph"),
+            "mode-0 text paints a glyph run: {base_kinds:?}"
+        );
+
+        let fi = clip_kinds.iter().position(|k| *k == "fill").expect("fill");
+        assert!(
+            clip_kinds[..fi].contains(&"push"),
+            "text clip pushed before the fill: {clip_kinds:?}"
+        );
+        let bfi = base_kinds.iter().position(|k| *k == "fill").expect("fill");
+        assert!(
+            !base_kinds[..bfi].contains(&"push"),
+            "no clip without a clip render mode: {base_kinds:?}"
+        );
+
+        assert_eq!(
+            clip_kinds.iter().filter(|k| **k == "push").count(),
+            clip_kinds.iter().filter(|k| **k == "pop").count(),
+            "clips balanced: {clip_kinds:?}"
+        );
     }
 
     // ---- Ruled-line capture (rule sink for table detection) ----

--- a/crates/zpdf-content/tests/form_font_object_id.rs
+++ b/crates/zpdf-content/tests/form_font_object_id.rs
@@ -1,0 +1,101 @@
+//! Two sibling form XObjects that reuse the same font resource name (`/R7`) for
+//! *different* font objects must not collide in the shared FontCache. Keying by
+//! name (or by form-depth+name) let the first form's font win, so the second
+//! form's text rendered with the wrong subset. Keying by the font's object id
+//! gives each distinct font its own cache slot.
+
+use zpdf_content::interpreter::ContentInterpreter;
+use zpdf_core::Rect;
+use zpdf_document::PdfDocument;
+use zpdf_font::FontCache;
+
+/// Page invokes two forms; each form's /Resources/Font maps the *same* name
+/// `/R7` to a *different* font object (7 vs 8). The page itself declares no
+/// fonts. `load_form_fonts` loads every font a form references when the form is
+/// invoked, so the form bodies can be empty.
+fn build_pdf() -> Vec<u8> {
+    let content: &[u8] = b"/Fm1 Do /Fm2 Do";
+    let form_body: &[u8] = b""; // no marks needed; fonts load on invocation
+
+    let form = |font_obj: u32| -> Vec<u8> {
+        let mut v = format!(
+            "<< /Type /XObject /Subtype /Form /BBox [0 0 100 100] \
+             /Resources << /Font << /R7 {font_obj} 0 R >> >> /Length {} >>\nstream\n",
+            form_body.len()
+        )
+        .into_bytes();
+        v.extend_from_slice(form_body);
+        v.extend_from_slice(b"\nendstream");
+        v
+    };
+
+    let objs: Vec<(u32, Vec<u8>)> = vec![
+        (1, b"<< /Type /Catalog /Pages 2 0 R >>".to_vec()),
+        (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec()),
+        (
+            3,
+            b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] \
+              /Resources << /XObject << /Fm1 5 0 R /Fm2 6 0 R >> >> /Contents 4 0 R >>"
+                .to_vec(),
+        ),
+        (4, {
+            let mut v = format!("<< /Length {} >>\nstream\n", content.len()).into_bytes();
+            v.extend_from_slice(content);
+            v.extend_from_slice(b"\nendstream");
+            v
+        }),
+        (5, form(7)),
+        (6, form(8)),
+        (7, b"<< /Type /Font /Subtype /Type1 /BaseFont /FontA >>".to_vec()),
+        (8, b"<< /Type /Font /Subtype /Type1 /BaseFont /FontB >>".to_vec()),
+    ];
+
+    let mut out = b"%PDF-1.4\n".to_vec();
+    let mut offsets = Vec::new();
+    for (num, body) in &objs {
+        offsets.push(out.len());
+        out.extend_from_slice(format!("{num} 0 obj\n").as_bytes());
+        out.extend_from_slice(body);
+        out.extend_from_slice(b"\nendobj\n");
+    }
+    let xref_off = out.len();
+    out.extend_from_slice(format!("xref\n0 {}\n", objs.len() + 1).as_bytes());
+    out.extend_from_slice(b"0000000000 65535 f \n");
+    for off in &offsets {
+        out.extend_from_slice(format!("{off:010} 00000 n \n").as_bytes());
+    }
+    out.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF",
+            objs.len() + 1,
+            xref_off
+        )
+        .as_bytes(),
+    );
+    out
+}
+
+#[test]
+fn sibling_forms_reusing_a_font_name_get_distinct_cache_slots() {
+    let doc = PdfDocument::open(build_pdf()).expect("parse synthetic PDF");
+    let page = doc.page(0).expect("page 0");
+    let content = doc.page_content_bytes(&page).expect("content");
+
+    // The page declares no fonts, so every FontCache entry after interpret comes
+    // from the two forms. Whether the font dicts load or fall back to a
+    // placeholder, each form contributes exactly one entry under its object-id
+    // key — so two distinct font objects yield two entries. Keying by name would
+    // give one (the second form reusing the first's slot).
+    let mut cache = FontCache::new();
+    let _ = ContentInterpreter::new(Rect::new(0.0, 0.0, 200.0, 200.0))
+        .with_fonts(&mut cache)
+        .with_document(doc.file(), &page.resources)
+        .interpret(&content);
+
+    assert_eq!(
+        cache.len(),
+        2,
+        "two sibling forms reusing /R7 for different font objects must occupy \
+         two cache slots, not collide into one"
+    );
+}

--- a/crates/zpdf-document/src/font_loader.rs
+++ b/crates/zpdf-document/src/font_loader.rs
@@ -767,7 +767,20 @@ fn parse_cid_widths(file: &PdfFile, dict: &zpdf_core::PdfDict) -> CidWidths {
             break;
         }
 
-        match &w_array[i] {
+        // In the `[cid [w1 w2 ...]]` form the width sub-array is frequently an
+        // *indirect* reference (AutoCAD/nanoCAD export /W this way). Resolve one
+        // level so the `PdfObject::Array` arm below sees it; otherwise the entry
+        // fell through to `_ => i += 1`, the sub-array was skipped, and every CID
+        // in the range silently defaulted to /DW — breaking advances (and thus
+        // inter-glyph spacing), so the text drifts.
+        let resolved = if let PdfObject::Ref(id) = &w_array[i] {
+            file.resolve(*id).ok()
+        } else {
+            None
+        };
+        let entry = resolved.as_ref().unwrap_or(&w_array[i]);
+
+        match entry {
             PdfObject::Array(arr) => {
                 // [cid_start [w1 w2 w3 ...]]
                 for (j, obj) in arr.iter().enumerate() {
@@ -785,7 +798,7 @@ fn parse_cid_widths(file: &PdfFile, dict: &zpdf_core::PdfDict) -> CidWidths {
             }
             PdfObject::Integer(_) | PdfObject::Real(_) => {
                 // [cid_start cid_end width]
-                let cid_end = w_array[i]
+                let cid_end = entry
                     .as_i64()
                     .ok()
                     .and_then(|v| u16::try_from(v).ok())

--- a/crates/zpdf-document/src/font_loader.rs
+++ b/crates/zpdf-document/src/font_loader.rs
@@ -76,19 +76,17 @@ fn substitute_hints(
     dict: &zpdf_core::PdfDict,
 ) -> zpdf_font::system::SubstituteHints {
     let mut hints = zpdf_font::system::SubstituteHints::default();
-    if let Ok(fd_ref) = dict.get_ref("FontDescriptor") {
-        if let Ok(fd) = file.resolve(fd_ref) {
-            if let Ok(fd) = fd.as_dict() {
-                if let Ok(flags) = fd.get_i64("Flags") {
-                    hints.fixed_pitch = flags & 1 != 0;
-                    hints.serif = flags & 2 != 0;
-                    hints.italic = flags & 64 != 0;
-                    hints.bold = flags & (1 << 18) != 0; // ForceBold
-                }
-                if let Ok(w) = fd.get_f64("StemV") {
-                    hints.bold |= w >= 160.0;
-                }
-            }
+    // /FontDescriptor must be indirect per spec, but AutoCAD and other producers
+    // inline it; resolve_dict accepts both forms.
+    if let Some(fd) = resolve_dict(file, dict, "FontDescriptor") {
+        if let Ok(flags) = fd.get_i64("Flags") {
+            hints.fixed_pitch = flags & 1 != 0;
+            hints.serif = flags & 2 != 0;
+            hints.italic = flags & 64 != 0;
+            hints.bold = flags & (1 << 18) != 0; // ForceBold
+        }
+        if let Ok(w) = fd.get_f64("StemV") {
+            hints.bold |= w >= 160.0;
         }
     }
     hints
@@ -185,14 +183,8 @@ fn builtin_symbol_encoding(base_font: &str) -> Option<zpdf_font::encoding::Encod
 /// Read the FontDescriptor /Flags and decide whether the font is symbolic
 /// (bit 3 set, bit 6 clear).
 fn font_descriptor_symbolic(file: &PdfFile, dict: &zpdf_core::PdfDict) -> bool {
-    let fd_ref = match dict.get_ref("FontDescriptor") {
-        Ok(r) => r,
-        Err(_) => return false,
-    };
-    let flags = file
-        .resolve(fd_ref)
-        .ok()
-        .and_then(|o| o.as_dict().ok().and_then(|d| d.get_i64("Flags").ok()));
+    let flags =
+        resolve_dict(file, dict, "FontDescriptor").and_then(|d| d.get_i64("Flags").ok());
     matches!(flags, Some(f) if (f & 4) != 0 && (f & 32) == 0)
 }
 
@@ -202,13 +194,22 @@ fn font_descriptor_symbolic(file: &PdfFile, dict: &zpdf_core::PdfDict) -> bool {
 fn font_descriptor_dict(file: &PdfFile, dict: &zpdf_core::PdfDict) -> Option<zpdf_core::PdfDict> {
     let host = if dict.get_name("Subtype").unwrap_or("") == "Type0" {
         let descendants = resolve_array(file, dict, "DescendantFonts")?;
-        let desc_ref = descendants.first()?.as_ref().ok()?;
-        file.resolve(desc_ref).ok()?.as_dict().ok()?.clone()
+        descendant_cid_dict(file, &descendants)?
     } else {
         dict.clone()
     };
-    let fd_ref = host.get_ref("FontDescriptor").ok()?;
-    file.resolve(fd_ref).ok()?.as_dict().ok().cloned()
+    resolve_dict(file, &host, "FontDescriptor")
+}
+
+/// The first /DescendantFonts entry as a dict. The spec requires an indirect
+/// reference, but AutoCAD and other producers inline the CIDFont dict directly
+/// in the array; accept both forms.
+fn descendant_cid_dict(file: &PdfFile, descendants: &[PdfObject]) -> Option<zpdf_core::PdfDict> {
+    match descendants.first()? {
+        PdfObject::Dict(d) => Some(d.clone()),
+        PdfObject::Ref(r) => file.resolve(*r).ok()?.as_dict().ok().cloned(),
+        _ => None,
+    }
 }
 
 /// Map a `/FontStretch` name to its OpenType `wdth`-axis percentage (Table 122).
@@ -366,13 +367,11 @@ fn load_type0_font(
     // /DescendantFonts is commonly an indirect reference to the array.
     let descendants = resolve_array(file, dict, "DescendantFonts")
         .ok_or_else(|| zpdf_core::Error::MissingKey("DescendantFonts".into()))?;
-    let desc_ref = descendants
-        .first()
-        .ok_or_else(|| zpdf_core::Error::MissingKey("DescendantFonts[0]".into()))?
-        .as_ref()?;
-
-    let desc_obj = file.resolve(desc_ref)?;
-    let desc_dict = desc_obj.as_dict()?;
+    // /DescendantFonts is commonly an indirect reference to the array; the
+    // CIDFont entry itself may also be inlined (AutoCAD) instead of a ref.
+    let desc_dict = descendant_cid_dict(file, &descendants)
+        .ok_or_else(|| zpdf_core::Error::MissingKey("DescendantFonts[0]".into()))?;
+    let desc_dict = &desc_dict;
 
     let mut cid_widths = parse_cid_widths(file, desc_dict);
     parse_cid_w2(file, desc_dict, &mut cid_widths);
@@ -677,9 +676,7 @@ fn load_type1_font(
 
 /// Extract embedded font binary from FontDescriptor → FontFile2 (TrueType).
 fn extract_font_file(file: &PdfFile, cid_dict: &zpdf_core::PdfDict) -> Option<Vec<u8>> {
-    let fd_ref = cid_dict.get_ref("FontDescriptor").ok()?;
-    let fd_obj = file.resolve(fd_ref).ok()?;
-    let fd_dict = fd_obj.as_dict().ok()?;
+    let fd_dict = resolve_dict(file, cid_dict, "FontDescriptor")?;
 
     // Try FontFile2 (TrueType), then FontFile3 (OpenType/CFF), then FontFile (Type1)
     for key in &["FontFile2", "FontFile3", "FontFile"] {
@@ -698,9 +695,7 @@ fn extract_font_file_from_descriptor(
     file: &PdfFile,
     font_dict: &zpdf_core::PdfDict,
 ) -> Option<Vec<u8>> {
-    let fd_ref = font_dict.get_ref("FontDescriptor").ok()?;
-    let fd_obj = file.resolve(fd_ref).ok()?;
-    let fd_dict = fd_obj.as_dict().ok()?;
+    let fd_dict = resolve_dict(file, font_dict, "FontDescriptor")?;
 
     for key in &["FontFile2", "FontFile3", "FontFile"] {
         if let Ok(ff_ref) = fd_dict.get_ref(key) {

--- a/crates/zpdf-document/tests/font_loader_indirect.rs
+++ b/crates/zpdf-document/tests/font_loader_indirect.rs
@@ -191,3 +191,35 @@ fn type3_indirect_refs_resolve() {
     assert_eq!(font.type3_glyph_width(65), 500.0);
     assert_eq!(font.type3_glyph_width(66), 600.0);
 }
+
+#[test]
+fn cid_w_indirect_width_subarray_resolves() {
+    // A /W entry's width sub-array `[w1 w2 ...]` is often an INDIRECT reference
+    // (AutoCAD/nanoCAD export). Without resolving it the entry is skipped and
+    // every CID falls back to /DW — advances (and inter-glyph spacing) break, so
+    // text drifts. Here CIDs 10,11,12 must pick up 111,222,333, not /DW 1000.
+    let pdf = build_pdf(&[
+        dict_obj("<< /Type /Catalog >>"),
+        dict_obj(
+            "<< /Type /Font /Subtype /Type0 /BaseFont /T /Encoding /Identity-H \
+             /DescendantFonts [3 0 R] >>",
+        ),
+        dict_obj(
+            "<< /Type /Font /Subtype /CIDFontType2 /BaseFont /T /FontDescriptor 4 0 R \
+             /CIDToGIDMap /Identity /DW 1000 /W [ 10 5 0 R ] >>",
+        ),
+        dict_obj("<< /Type /FontDescriptor /FontName /T /Flags 4 >>"),
+        dict_obj("[ 111 222 333 ]"),
+    ]);
+
+    let file = PdfFile::parse(pdf).expect("parse synthetic pdf");
+    let font = load_single_font(&file, ObjectId(2, 0)).expect("load font");
+    assert_eq!(font.cid_widths.get(10), 111.0);
+    assert_eq!(font.cid_widths.get(11), 222.0);
+    assert_eq!(font.cid_widths.get(12), 333.0);
+    assert_eq!(
+        font.cid_widths.get_opt(9),
+        None,
+        "CIDs outside /W keep /DW (not set)"
+    );
+}

--- a/crates/zpdf-document/tests/font_loader_indirect.rs
+++ b/crates/zpdf-document/tests/font_loader_indirect.rs
@@ -191,3 +191,55 @@ fn type3_indirect_refs_resolve() {
     assert_eq!(font.type3_glyph_width(65), 500.0);
     assert_eq!(font.type3_glyph_width(66), 600.0);
 }
+
+#[test]
+fn inline_font_descriptor_resolves() {
+    // AutoCAD (and other producers) emit the CIDFont's /FontDescriptor as an
+    // INLINE dict, though ISO 32000 requires an indirect reference. A
+    // spec-strict, `get_ref`-only read finds no descriptor, so the embedded
+    // /FontFile is never extracted and the font falls back to a substitute.
+    // `resolve_dict` accepts both forms; the embedded program must attach.
+    let pdf = build_pdf(&[
+        dict_obj("<< /Type /Catalog >>"),
+        dict_obj(
+            "<< /Type /Font /Subtype /Type0 /BaseFont /T /Encoding /Identity-H \
+             /DescendantFonts [3 0 R] >>",
+        ),
+        dict_obj(
+            "<< /Type /Font /Subtype /CIDFontType0 /BaseFont /T /CIDToGIDMap /Identity /DW 1000 \
+             /FontDescriptor << /Type /FontDescriptor /FontName /T /Flags 4 /FontFile3 4 0 R >> >>",
+        ),
+        stream_obj(&cid_keyed_cff()),
+    ]);
+
+    let file = PdfFile::parse(pdf).expect("parse synthetic pdf");
+    let font = load_single_font(&file, ObjectId(2, 0)).expect("load font");
+    assert!(
+        font.has_font_data(),
+        "inline /FontDescriptor resolved and /FontFile3 program parsed"
+    );
+}
+
+#[test]
+fn inline_descendant_cidfont_resolves() {
+    // The /DescendantFonts entry itself may be an inline CIDFont dict rather
+    // than an indirect reference (AutoCAD). The descendant's embedded font
+    // program must still load.
+    let pdf = build_pdf(&[
+        dict_obj("<< /Type /Catalog >>"),
+        dict_obj(
+            "<< /Type /Font /Subtype /Type0 /BaseFont /T /Encoding /Identity-H \
+             /DescendantFonts [ << /Type /Font /Subtype /CIDFontType0 /BaseFont /T \
+             /CIDToGIDMap /Identity /DW 1000 /FontDescriptor 3 0 R >> ] >>",
+        ),
+        dict_obj("<< /Type /FontDescriptor /FontName /T /Flags 4 /FontFile3 4 0 R >>"),
+        stream_obj(&cid_keyed_cff()),
+    ]);
+
+    let file = PdfFile::parse(pdf).expect("parse synthetic pdf");
+    let font = load_single_font(&file, ObjectId(2, 0)).expect("load font");
+    assert!(
+        font.has_font_data(),
+        "inline /DescendantFonts CIDFont dict resolved and program loaded"
+    );
+}


### PR DESCRIPTION
Integrates the reviewed, low-risk contributor fixes from #11, #12, #13, #14, and #18 while preserving their original commits.

## Contributor credit

Original implementation for all five integrated PRs: @lFLouSel. The authored commits are preserved in this merge.

Included:
- CID font `/W` indirect sub-array and inline descriptor/descendant compatibility.
- Text clipping for render modes 4–7.
- `ContentInterpreter::with_content_translation`.
- Form XObject font-cache keys scoped by object id.

Integration work:
- Resolved independent test-anchor conflicts and retained all regressions.
- Applied `cargo fmt` to the source PRs whose only CI failure was rustfmt.

Verified with `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --no-fail-fast`, and `cargo build -p zpdf --features gpu-render --verbose`.

Closes #11
Closes #12
Closes #13
Closes #14
Closes #18