### PR TITLE
Writer-side feature gaps: CJK authoring, Tagged/UA, PDF/A conversion, production signing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,9 @@ sha2 = "0.10"
 rsa = "0.9"
 p256 = { version = "0.13", default-features = false, features = ["ecdsa", "std"] }
 p384 = { version = "0.13", default-features = false, features = ["ecdsa", "std"] }
+# Pure-Rust HTTP for the optional RFC 3161 timestamp requester (behind the
+# zpdf-writer `timestamp` feature); ureq's `tls` feature uses rustls (C-free).
+ureq = { version = "2", default-features = false, features = ["tls"] }
 zune-jpeg = "0.5"
 # Pure-Rust JPEG 2000 decoder (JPXDecode) from the hayro PDF renderer family.
 # Hand-written, #![forbid(unsafe_code)] at the crate level; the optional `simd`

--- a/crates/zpdf-cli/Cargo.toml
+++ b/crates/zpdf-cli/Cargo.toml
@@ -19,6 +19,9 @@ path = "src/main.rs"
 default = ["cpu"]
 cpu = ["zpdf/cpu-render"]
 gpu = ["zpdf/gpu-render"]
+# Enables the `--tsa` RFC 3161 timestamp option for `zpdf sign` (pure-Rust
+# HTTP via zpdf-writer's ureq backend).
+timestamp = ["zpdf-writer/timestamp"]
 
 [dependencies]
 zpdf = { workspace = true, default-features = false }

--- a/crates/zpdf-cli/src/main.rs
+++ b/crates/zpdf-cli/src/main.rs
@@ -652,6 +652,29 @@ fn cmd_signatures(args: &[String]) -> zpdf::Result<()> {
             println!("    => Cryptographically sound (bytes intact + signature valid); trust anchor NOT validated");
         }
 
+        // Production-grade metadata: embedded timestamp, DSS, cert count, revocation.
+        println!(
+            "    Timestamp: {}",
+            if s.has_timestamp {
+                "present (RFC 3161 unsignedAttr)"
+            } else {
+                "none"
+            }
+        );
+        println!("    Embedded certs: {}", s.cert_count);
+        println!(
+            "    /DSS (LTV): {}",
+            if s.has_dss { "present" } else { "absent" }
+        );
+        println!(
+            "    Revocation: {}",
+            match s.revocation {
+                zpdf::RevocationStatus::Unknown => "unknown (no CRL embedded)",
+                zpdf::RevocationStatus::NotRevoked => "not revoked (per embedded CRL)",
+                zpdf::RevocationStatus::Revoked => "REVOKED (per embedded CRL)",
+            }
+        );
+
         // Certificate-chain verification against the provided anchors.
         if let Some(anchors) = &anchors {
             let verdict = match &s.cms_blob {
@@ -2248,6 +2271,12 @@ fn cmd_sign(args: &[String]) -> zpdf::Result<()> {
     let mut name: Option<String> = None;
     let mut reason: Option<String> = None;
     let mut location: Option<String> = None;
+    let mut subfilter = zpdf_writer::SubFilter::AdbePkcs7Detached;
+    let mut appearance = false;
+    let mut appearance_rect: Option<String> = None;
+    let mut tsa_url: Option<String> = None;
+    let mut cert_chain_paths: Vec<String> = Vec::new();
+    let mut crl_paths: Vec<String> = Vec::new();
 
     let mut i = 0;
     while i < args.len() {
@@ -2270,6 +2299,48 @@ fn cmd_sign(args: &[String]) -> zpdf::Result<()> {
             }
             "--location" => {
                 location = args.get(i + 1).cloned();
+                i += 2;
+            }
+            "--subfilter" => {
+                subfilter = match args.get(i + 1).map(String::as_str) {
+                    Some("pkcs7") | Some("adbe.pkcs7.detached") => {
+                        zpdf_writer::SubFilter::AdbePkcs7Detached
+                    }
+                    Some("cades") | Some("ETSI.CAdES.detached") => {
+                        zpdf_writer::SubFilter::EtsiCAdESDetached
+                    }
+                    other => {
+                        eprintln!(
+                            "Unknown --subfilter {:?} (use pkcs7 or cades)",
+                            other.unwrap_or("")
+                        );
+                        process::exit(1);
+                    }
+                };
+                i += 2;
+            }
+            "--appearance" => {
+                appearance = true;
+                i += 1;
+            }
+            "--appearance-rect" => {
+                appearance_rect = args.get(i + 1).cloned();
+                i += 2;
+            }
+            "--tsa" => {
+                tsa_url = args.get(i + 1).cloned();
+                i += 2;
+            }
+            "--cert-chain" => {
+                if let Some(p) = args.get(i + 1) {
+                    cert_chain_paths.push(p.clone());
+                }
+                i += 2;
+            }
+            "--crl" => {
+                if let Some(p) = args.get(i + 1) {
+                    crl_paths.push(p.clone());
+                }
                 i += 2;
             }
             "-o" => {
@@ -2299,10 +2370,64 @@ fn cmd_sign(args: &[String]) -> zpdf::Result<()> {
         process::exit(1);
     }
 
-    let key_der = fs::read(&key_path).map_err(zpdf::Error::Io)?;
-    let cert_der = fs::read(&cert_path).map_err(zpdf::Error::Io)?;
-    let key = zpdf_writer::SigningKey::from_pkcs8_der(&key_der)
-        .or_else(|_| zpdf_writer::SigningKey::rsa_from_pkcs1_der(&key_der))?;
+    let key_bytes = fs::read(&key_path).map_err(zpdf::Error::Io)?;
+    let cert_bytes = fs::read(&cert_path).map_err(zpdf::Error::Io)?;
+    // Auto-detect PEM vs DER for both key and cert.
+    let key = if key_bytes.starts_with(b"-----BEGIN") {
+        zpdf_writer::SigningKey::from_pem(&key_bytes)?
+    } else {
+        zpdf_writer::SigningKey::from_pkcs8_der(&key_bytes)
+            .or_else(|_| zpdf_writer::SigningKey::rsa_from_pkcs1_der(&key_bytes))?
+    };
+    let cert_der = if cert_bytes.starts_with(b"-----BEGIN CERTIFICATE-----") {
+        zpdf_writer::sign::pem_decode(&cert_bytes, "CERTIFICATE")?
+    } else {
+        cert_bytes
+    };
+
+    let extra_certs: Vec<Vec<u8>> = cert_chain_paths
+        .iter()
+        .map(|p| {
+            let b = fs::read(p).map_err(zpdf::Error::Io)?;
+            if b.starts_with(b"-----BEGIN CERTIFICATE-----") {
+                zpdf_writer::sign::pem_decode(&b, "CERTIFICATE")
+            } else {
+                Ok(b)
+            }
+        })
+        .collect::<zpdf::Result<_>>()?;
+    let crls: Vec<Vec<u8>> = crl_paths
+        .iter()
+        .map(|p| fs::read(p).map_err(zpdf::Error::Io))
+        .collect::<zpdf::Result<_>>()?;
+
+    let appearance = if appearance {
+        let rect = match appearance_rect.as_deref() {
+            Some(s) => parse_rect(s).unwrap_or_else(|| {
+                eprintln!("--appearance-rect X0,Y0,X1,Y1 required with --appearance");
+                process::exit(1);
+            }),
+            None => zpdf::Rect::new(20.0, 20.0, 220.0, 60.0),
+        };
+        Some(zpdf_writer::AppearanceSpec {
+            rect,
+            ..Default::default()
+        })
+    } else {
+        None
+    };
+
+    let timestamp = match tsa_url {
+        #[cfg(feature = "timestamp")]
+        Some(url) => Some(Box::new(zpdf_writer::UreqTimestampRequester::new(url))
+            as Box<dyn zpdf_writer::TimestampRequester>),
+        #[cfg(not(feature = "timestamp"))]
+        Some(_) => {
+            eprintln!("--tsa requires building zpdf with the `timestamp` feature");
+            process::exit(1);
+        }
+        None => None,
+    };
 
     let writer = build_writer(&input_path, password.as_deref())?;
     let signed = writer.sign(
@@ -2312,6 +2437,11 @@ fn cmd_sign(args: &[String]) -> zpdf::Result<()> {
             name,
             reason,
             location,
+            subfilter,
+            appearance,
+            extra_certs,
+            crls,
+            timestamp,
             ..Default::default()
         },
     )?;
@@ -2319,6 +2449,16 @@ fn cmd_sign(args: &[String]) -> zpdf::Result<()> {
     println!("Signed → {out_path}");
     println!("Note: certificate chain trust is not established by zpdf; viewers will show the signer as untrusted unless the certificate is in their trust store.");
     Ok(())
+}
+
+/// Parse a `X0,Y0,X1,Y1` rect string.
+fn parse_rect(s: &str) -> Option<zpdf::Rect> {
+    let parts: Vec<f64> = s.split(',').filter_map(|p| p.trim().parse().ok()).collect();
+    if parts.len() == 4 {
+        Some(zpdf::Rect::new(parts[0], parts[1], parts[2], parts[3]))
+    } else {
+        None
+    }
 }
 
 /// `input.pdf` → `input-split.pdf` or `input-3.pdf` for a page number.

--- a/crates/zpdf-cli/src/main.rs
+++ b/crates/zpdf-cli/src/main.rs
@@ -1866,6 +1866,9 @@ fn cmd_optimize(args: &[String]) -> zpdf::Result<()> {
     let mut owner_pw = String::new();
     let mut max_image_dim: Option<u32> = None;
     let mut linearize = false;
+    let mut pdfa: Option<String> = None;
+    let mut fallback_font_path: Option<String> = None;
+    let mut icc_path: Option<String> = None;
 
     let mut i = 0;
     while i < args.len() {
@@ -1902,6 +1905,18 @@ fn cmd_optimize(args: &[String]) -> zpdf::Result<()> {
                 linearize = true;
                 i += 1;
             }
+            "--pdfa" => {
+                pdfa = args.get(i + 1).cloned();
+                i += 2;
+            }
+            "--fallback-font" => {
+                fallback_font_path = args.get(i + 1).cloned();
+                i += 2;
+            }
+            "--icc" => {
+                icc_path = args.get(i + 1).cloned();
+                i += 2;
+            }
             other if !other.starts_with('-') => {
                 if input.is_none() {
                     input = Some(other.to_string());
@@ -1934,15 +1949,52 @@ fn cmd_optimize(args: &[String]) -> zpdf::Result<()> {
         }
     };
 
+    let pdfa = match pdfa.as_deref() {
+        None => None,
+        Some("pdfa-1b") | Some("a-1b") => Some(zpdf_writer::PdfaProfile::A1b),
+        Some("pdfa-2b") | Some("a-2b") => Some(zpdf_writer::PdfaProfile::A2b),
+        Some(other) => {
+            eprintln!("Unknown --pdfa profile: {other} (use pdfa-1b or pdfa-2b)");
+            process::exit(1);
+        }
+    };
+    if pdfa.is_some() && encrypt.is_some() {
+        eprintln!("--pdfa cannot be combined with --encrypt (PDF/A forbids encryption)");
+        process::exit(1);
+    }
+    if pdfa.is_some() && linearize {
+        eprintln!("--pdfa cannot be combined with --linearize (use one or the other)");
+        process::exit(1);
+    }
+    let pdfa = match pdfa {
+        None => None,
+        Some(profile) => {
+            let icc = match icc_path.as_deref() {
+                Some(p) => Some(std::fs::read(p).map_err(zpdf::Error::Io)?),
+                None => None,
+            };
+            let fallback_font = match fallback_font_path.as_deref() {
+                Some(p) => Some(std::fs::read(p).map_err(zpdf::Error::Io)?),
+                None => None,
+            };
+            Some(zpdf_writer::PdfaConvertConfig {
+                profile,
+                icc,
+                fallback_font,
+            })
+        }
+    };
+
     let doc = open_document(&input_path, password.as_deref())?;
     warn_signatures(&doc);
-    if doc.is_encrypted() && encrypt.is_none() {
+    if doc.is_encrypted() && encrypt.is_none() && pdfa.is_none() {
         eprintln!("Note: output will be decrypted (rewrite drops /Encrypt).");
     }
     let options = zpdf_writer::RewriteOptions {
         compress_uncompressed: !no_compress,
         encrypt,
         max_image_dimension: max_image_dim,
+        pdfa,
     };
     let bytes = if linearize {
         if encrypt_algo.is_some() {

--- a/crates/zpdf-cli/src/main.rs
+++ b/crates/zpdf-cli/src/main.rs
@@ -2570,18 +2570,27 @@ fn cmd_redact(args: &[String]) -> zpdf::Result<()> {
 fn cmd_validate(args: &[String]) -> zpdf::Result<()> {
     let (args, password) = extract_password(args);
     let mut input: Option<&str> = None;
-    let mut profile = zpdf::pdfa::Profile::A2b;
+    enum Profile {
+        Pdfa(zpdf::pdfa::Profile),
+        Pdfua(zpdf::pdfua::Profile),
+    }
+    let mut profile = Profile::Pdfa(zpdf::pdfa::Profile::A2b);
 
     let mut i = 0;
     while i < args.len() {
         match args[i].as_str() {
             "--profile" => {
                 profile = match args.get(i + 1).map(String::as_str) {
-                    Some("pdfa-1b") | Some("a-1b") | Some("1b") => zpdf::pdfa::Profile::A1b,
-                    Some("pdfa-2b") | Some("a-2b") | Some("2b") => zpdf::pdfa::Profile::A2b,
+                    Some("pdfa-1b") | Some("a-1b") | Some("1b") => {
+                        Profile::Pdfa(zpdf::pdfa::Profile::A1b)
+                    }
+                    Some("pdfa-2b") | Some("a-2b") | Some("2b") => {
+                        Profile::Pdfa(zpdf::pdfa::Profile::A2b)
+                    }
+                    Some("pdfua-1") | Some("ua-1") => Profile::Pdfua(zpdf::pdfua::Profile::Ua1),
                     other => {
                         eprintln!(
-                            "Unknown profile {:?} (use pdfa-1b or pdfa-2b)",
+                            "Unknown profile {:?} (use pdfa-1b, pdfa-2b, or pdfua-1)",
                             other.unwrap_or("")
                         );
                         process::exit(1);
@@ -2599,26 +2608,44 @@ fn cmd_validate(args: &[String]) -> zpdf::Result<()> {
         }
     }
     let Some(input) = input else {
-        eprintln!("Usage: zpdf validate <file.pdf> [--profile pdfa-1b|pdfa-2b] [--password <pw>]");
+        eprintln!(
+            "Usage: zpdf validate <file.pdf> [--profile pdfa-1b|pdfa-2b|pdfua-1] [--password <pw>]"
+        );
         process::exit(1);
     };
 
     let doc = open_document(input, password.as_deref())?;
-    let report = zpdf::pdfa::validate(doc.file(), profile);
-
-    println!("Profile: {}", report.profile.as_str());
-    match &report.claimed {
-        Some((part, conf)) => println!("Claimed: PDF/A-{part}{}", conf.to_lowercase()),
-        None => println!("Claimed: (no PDF/A identification in XMP)"),
-    }
-    if report.conforms() {
-        println!("Result: PASS — no violations found");
-    } else {
-        println!("Result: FAIL — {} violation(s)", report.violations.len());
-        for v in &report.violations {
-            println!("  [{}] {}", v.rule, v.message);
+    match profile {
+        Profile::Pdfa(p) => {
+            let report = zpdf::pdfa::validate(doc.file(), p);
+            println!("Profile: {}", report.profile.as_str());
+            match &report.claimed {
+                Some((part, conf)) => println!("Claimed: PDF/A-{part}{}", conf.to_lowercase()),
+                None => println!("Claimed: (no PDF/A identification in XMP)"),
+            }
+            if report.conforms() {
+                println!("Result: PASS — no violations found");
+            } else {
+                println!("Result: FAIL — {} violation(s)", report.violations.len());
+                for v in &report.violations {
+                    println!("  [{}] {}", v.rule, v.message);
+                }
+                process::exit(3);
+            }
         }
-        process::exit(3);
+        Profile::Pdfua(p) => {
+            let report = zpdf::pdfua::validate(doc.file(), p);
+            println!("Profile: {}", report.profile.as_str());
+            if report.conforms() {
+                println!("Result: PASS — no violations found");
+            } else {
+                println!("Result: FAIL — {} violation(s)", report.violations.len());
+                for v in &report.violations {
+                    println!("  [{}] {}", v.rule, v.message);
+                }
+                process::exit(3);
+            }
+        }
     }
     Ok(())
 }

--- a/crates/zpdf-document/src/lib.rs
+++ b/crates/zpdf-document/src/lib.rs
@@ -38,7 +38,7 @@ pub use outline::OutlineItem;
 pub use output_intents::OutputIntent;
 pub use page::{PdfPage, ResourceDict};
 pub use page_labels::{PageLabelStyle, PageLabels};
-pub use signature::{ByteRangeCoverage, CryptoStatus, DigestStatus, Signature};
+pub use signature::{ByteRangeCoverage, CryptoStatus, DigestStatus, RevocationStatus, Signature};
 pub use structure::{StructElem, StructKid, StructRole, StructTree};
 pub use xmp::XmpMetadata;
 

--- a/crates/zpdf-document/src/lib.rs
+++ b/crates/zpdf-document/src/lib.rs
@@ -15,6 +15,7 @@ pub mod output_intents;
 pub mod page;
 pub mod page_labels;
 pub mod pdfa;
+pub mod pdfua;
 pub mod signature;
 pub mod structure;
 pub mod trust;

--- a/crates/zpdf-document/src/pdfua.rs
+++ b/crates/zpdf-document/src/pdfua.rs
@@ -1,0 +1,357 @@
+//! PDF/UA-1 conformance validation (ISO 14289-1).
+//!
+//! A rule engine over the parsed document, mirroring [`crate::pdfa`]: each
+//! check inspects one aspect and yields zero or more [`Violation`]s. This
+//! covers the high-signal, machine-checkable clauses of PDF/UA-1 (the
+//! "Universal Accessibility" conformance):
+//!
+//! - the document is tagged (`/MarkInfo /Marked true`)
+//! - a `/StructTreeRoot` is present and non-empty
+//! - the catalog declares a `/Lang` (BCP 47)
+//! - every `/Figure` structure element carries `/Alt` or `/ActualText`
+//! - the structure tree contains at least one heading (`H` / `H1`…`H6`)
+//! - every structure role is a standard type or mapped onto one via `/RoleMap`
+//!   (no unresolved `Other` roles)
+//! - every page carries `/StructParents`
+//!
+//! Everything is best-effort and read-only over `ParseLimits`-bounded APIs.
+//! Annotation `/OBJR` coverage and table-structure consistency are out of
+//! scope (first version).
+
+use std::collections::HashSet;
+
+use zpdf_core::{ObjectId, PdfObject};
+use zpdf_parser::PdfFile;
+
+use crate::catalog::Catalog;
+use crate::structure::{is_tagged, parse_struct_tree, StructElem, StructRole, StructTree};
+
+/// The validation profile.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Profile {
+    /// ISO 14289-1 (PDF/UA-1).
+    Ua1,
+}
+
+impl Profile {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Profile::Ua1 => "PDF/UA-1",
+        }
+    }
+}
+
+/// One conformance violation.
+#[derive(Debug, Clone)]
+pub struct Violation {
+    /// Short rule identifier, e.g. `"tagged"`, `"figure-alt"`.
+    pub rule: &'static str,
+    /// Human-readable explanation.
+    pub message: String,
+}
+
+/// The outcome of a validation run.
+#[derive(Debug)]
+pub struct ValidationReport {
+    pub profile: Profile,
+    pub violations: Vec<Violation>,
+}
+
+impl ValidationReport {
+    pub fn conforms(&self) -> bool {
+        self.violations.is_empty()
+    }
+}
+
+/// Validate `file` against PDF/UA-1.
+pub fn validate(file: &PdfFile, profile: Profile) -> ValidationReport {
+    let mut v: Vec<Violation> = Vec::new();
+    check_tagged(file, &mut v);
+    let tree = check_struct_tree(file, &mut v);
+    check_lang(file, &mut v);
+    if let Some(tree) = &tree {
+        check_figures_have_alt(tree, &mut v);
+        check_has_heading(tree, &mut v);
+        check_roles_standard(tree, &mut v);
+    }
+    check_page_struct_parents(file, &mut v);
+    ValidationReport {
+        profile,
+        violations: v,
+    }
+}
+
+fn check_tagged(file: &PdfFile, out: &mut Vec<Violation>) {
+    if !is_tagged(file) {
+        out.push(Violation {
+            rule: "tagged",
+            message: "document is not tagged (/MarkInfo /Marked true absent); PDF/UA requires a tagged PDF".into(),
+        });
+    }
+}
+
+fn check_struct_tree(file: &PdfFile, out: &mut Vec<Violation>) -> Option<StructTree> {
+    let Ok(catalog) = Catalog::from_trailer(file) else {
+        out.push(Violation {
+            rule: "struct-tree",
+            message: "catalog cannot be built; no structure tree".into(),
+        });
+        return None;
+    };
+    match parse_struct_tree(file, &catalog) {
+        Some(tree) => {
+            if tree.element_count() == 0 {
+                out.push(Violation {
+                    rule: "struct-tree",
+                    message: "/StructTreeRoot is present but has no structure elements".into(),
+                });
+                return None;
+            }
+            Some(tree)
+        }
+        None => {
+            out.push(Violation {
+                rule: "struct-tree",
+                message: "no /StructTreeRoot; PDF/UA requires a structure tree".into(),
+            });
+            None
+        }
+    }
+}
+
+fn check_lang(file: &PdfFile, out: &mut Vec<Violation>) {
+    let Some(root) = crate::obj_util::catalog_dict(file) else {
+        out.push(Violation {
+            rule: "lang",
+            message: "catalog cannot be read; /Lang cannot be verified".into(),
+        });
+        return;
+    };
+    if root.get("Lang").is_none() {
+        out.push(Violation {
+            rule: "lang",
+            message: "catalog has no /Lang; PDF/UA requires a natural-language declaration".into(),
+        });
+    }
+}
+
+/// Walk the structure tree; every `Figure` must carry `/Alt` or `/ActualText`.
+fn check_figures_have_alt(tree: &StructTree, out: &mut Vec<Violation>) {
+    let mut missing = 0usize;
+    visit(tree.children.iter(), &mut |elem| {
+        if elem.role == StructRole::Figure && elem.accessible_text().is_none() {
+            missing += 1;
+        }
+    });
+    if missing > 0 {
+        out.push(Violation {
+            rule: "figure-alt",
+            message: format!("{missing} Figure element(s) lack /Alt and /ActualText; PDF/UA requires alternative text for figures"),
+        });
+    }
+}
+
+/// The tree must contain at least one heading.
+fn check_has_heading(tree: &StructTree, out: &mut Vec<Violation>) {
+    let mut has_heading = false;
+    visit(tree.children.iter(), &mut |elem| {
+        if elem.role.is_heading() {
+            has_heading = true;
+        }
+    });
+    if !has_heading {
+        out.push(Violation {
+            rule: "headings",
+            message: "structure tree has no heading (H / H1–H6); PDF/UA requires heading-based document structure".into(),
+        });
+    }
+}
+
+/// No element may carry an unresolved (non-standard, unmapped) role.
+fn check_roles_standard(tree: &StructTree, out: &mut Vec<Violation>) {
+    let mut bad: Vec<String> = Vec::new();
+    visit(tree.children.iter(), &mut |elem| {
+        if let StructRole::Other(name) = &elem.role {
+            bad.push(name.clone());
+        }
+    });
+    if !bad.is_empty() {
+        out.push(Violation {
+            rule: "role-unmapped",
+            message: format!(
+                "structure role(s) not mapped to a standard type via /RoleMap: {}",
+                bad.join(", ")
+            ),
+        });
+    }
+}
+
+/// Every page dict must carry `/StructParents`.
+fn check_page_struct_parents(file: &PdfFile, out: &mut Vec<Violation>) {
+    let Ok(root) = file.trailer.get_ref("Root") else {
+        return;
+    };
+    let Ok(catalog) = file.resolve(root).and_then(|o| o.as_dict().cloned()) else {
+        return;
+    };
+    let Ok(pages_root) = catalog.get_ref("Pages") else {
+        return;
+    };
+    let mut stack = vec![(pages_root, 0usize)];
+    let mut visited: HashSet<ObjectId> = HashSet::new();
+    let mut missing = 0usize;
+    while let Some((node, depth)) = stack.pop() {
+        if depth > 64 || !visited.insert(node) {
+            continue;
+        }
+        let Ok(dict) = file.resolve(node).and_then(|o| o.as_dict().cloned()) else {
+            continue;
+        };
+        // A leaf page (has /MediaBox or no /Kids) must carry /StructParents.
+        let is_leaf = dict.get("Kids").is_none();
+        if is_leaf && dict.get("StructParents").is_none() {
+            missing += 1;
+        }
+        if let Some(PdfObject::Array(kids)) = dict.get("Kids").map(|o| deref(file, o)).as_ref() {
+            for kid in kids {
+                if let PdfObject::Ref(r) = kid {
+                    stack.push((*r, depth + 1));
+                }
+            }
+        }
+    }
+    if missing > 0 {
+        out.push(Violation {
+            rule: "page-struct-parents",
+            message: format!("{missing} page(s) lack /StructParents; PDF/UA requires every page to participate in the structure tree"),
+        });
+    }
+}
+
+/// Depth-first visit over a structure-tree forest, calling `f` on every
+/// element (including nested ones). Bounded by the tree's own guards at parse
+/// time, so this walk cannot recurse without bound.
+fn visit<'a>(elems: impl Iterator<Item = &'a StructElem>, f: &mut dyn FnMut(&StructElem)) {
+    fn walk<'a>(elem: &'a StructElem, f: &mut dyn FnMut(&StructElem)) {
+        f(elem);
+        for child in elem.child_elements() {
+            walk(child, f);
+        }
+    }
+    for elem in elems {
+        walk(elem, f);
+    }
+}
+
+fn deref(file: &PdfFile, obj: &PdfObject) -> PdfObject {
+    match obj {
+        PdfObject::Ref(r) => file.resolve(*r).unwrap_or(PdfObject::Null),
+        other => other.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_util::build_pdf;
+
+    const PAGES: &str = "<< /Type /Pages /Kids [3 0 R] /Count 1 >>";
+    const PAGE: &str = "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /StructParents 0 >>";
+
+    fn open(objects: &[&str]) -> PdfFile {
+        PdfFile::parse(build_pdf(objects)).expect("parse pdf")
+    }
+
+    fn ua_pdf(catalog: &str, extra: &[&str]) -> PdfFile {
+        let mut objs = vec![catalog, PAGES, PAGE];
+        objs.extend_from_slice(extra);
+        open(&objs)
+    }
+
+    #[test]
+    fn untagged_pdf_fails() {
+        let file = ua_pdf("<< /Type /Catalog /Pages 2 0 R >>", &[]);
+        let r = validate(&file, Profile::Ua1);
+        let rules: Vec<&str> = r.violations.iter().map(|v| v.rule).collect();
+        assert!(rules.contains(&"tagged"));
+        assert!(rules.contains(&"struct-tree"));
+        assert!(rules.contains(&"lang"));
+        assert!(!r.conforms());
+    }
+
+    #[test]
+    fn compliant_tagged_pdf_passes() {
+        // StructTreeRoot → Document → [H1 (mcid 0), P (mcid 1)], /Lang set,
+        // /MarkInfo marked, page carries /StructParents.
+        let file = ua_pdf(
+            "<< /Type /Catalog /Pages 2 0 R /Lang (en) /MarkInfo << /Marked true >> \
+             /StructTreeRoot 4 0 R >>",
+            &[
+                // 4: StructTreeRoot
+                "<< /Type /StructTreeRoot /K 5 0 R /ParentTree 9 0 R /ParentTreeNextKey 1 >>",
+                // 5: Document
+                "<< /Type /StructElem /S /Document /P 4 0 R /K [6 0 R 7 0 R] >>",
+                // 6: H1
+                "<< /Type /StructElem /S /H1 /P 5 0 R /Pg 3 0 R /K 0 >>",
+                // 7: P
+                "<< /Type /StructElem /S /P /P 5 0 R /Pg 3 0 R /K 1 >>",
+                // 8: parent-tree array (H1, P in MCID order)
+                "<< 6 0 R 7 0 R >>",
+                // 9: ParentTree number tree
+                "<< /Nums [0 8 0 R] >>",
+            ],
+        );
+        let r = validate(&file, Profile::Ua1);
+        assert!(
+            r.conforms(),
+            "expected conformance, got: {:?}",
+            r.violations
+        );
+    }
+
+    #[test]
+    fn figure_without_alt_is_flagged() {
+        let file = ua_pdf(
+            "<< /Type /Catalog /Pages 2 0 R /Lang (en) /MarkInfo << /Marked true >> \
+             /StructTreeRoot 4 0 R >>",
+            &[
+                // 4: StructTreeRoot with two top-level elements (H1, Figure).
+                "<< /Type /StructTreeRoot /K [5 0 R 6 0 R] /ParentTree 7 0 R /ParentTreeNextKey 1 >>",
+                // 5: H1
+                "<< /Type /StructElem /S /H1 /P 4 0 R /Pg 3 0 R /K 0 >>",
+                // 6: Figure without /Alt or /ActualText
+                "<< /Type /StructElem /S /Figure /P 4 0 R /Pg 3 0 R /K 1 >>",
+                // 7: ParentTree
+                "<< /Nums [0 8 0 R] >>",
+                // 8: array
+                "<< 5 0 R 6 0 R >>",
+            ],
+        );
+        let r = validate(&file, Profile::Ua1);
+        let rules: Vec<&str> = r.violations.iter().map(|v| v.rule).collect();
+        assert!(
+            rules.contains(&"figure-alt"),
+            "figure-alt should fire: {rules:?}"
+        );
+    }
+
+    #[test]
+    fn no_heading_is_flagged() {
+        let file = ua_pdf(
+            "<< /Type /Catalog /Pages 2 0 R /Lang (en) /MarkInfo << /Marked true >> \
+             /StructTreeRoot 4 0 R >>",
+            &[
+                "<< /Type /StructTreeRoot /K 5 0 R /ParentTree 6 0 R /ParentTreeNextKey 1 >>",
+                "<< /Type /StructElem /S /P /P 4 0 R /Pg 3 0 R /K 0 >>",
+                "<< /Nums [0 7 0 R] >>",
+                "<< 5 0 R >>",
+            ],
+        );
+        let r = validate(&file, Profile::Ua1);
+        let rules: Vec<&str> = r.violations.iter().map(|v| v.rule).collect();
+        assert!(
+            rules.contains(&"headings"),
+            "headings should fire: {rules:?}"
+        );
+    }
+}

--- a/crates/zpdf-document/src/signature.rs
+++ b/crates/zpdf-document/src/signature.rs
@@ -101,6 +101,33 @@ pub struct Signature {
     /// as certificate-chain verification ([`crate::trust`]). `None` when the
     /// dictionary carried no string /Contents.
     pub cms_blob: Option<Vec<u8>>,
+    /// True when the CMS carries an RFC 3161 timestamp token in its
+    /// `unsignedAttrs` (a `signature-time-stamp` attribute). Best-effort
+    /// detection by OID scan; the TSA signature itself is not verified.
+    pub has_timestamp: bool,
+    /// Number of certificates embedded in the CMS `certificates` set (the
+    /// signer cert plus any chain), best-effort.
+    pub cert_count: usize,
+    /// Whether the document carries a `/DSS` (Document Security Store) on its
+    /// catalog — certs/CRLs/OCSP for LTV. `None` resolution falls back to false.
+    pub has_dss: bool,
+    /// Offline revocation status derived from CRLs embedded in the CMS or the
+    /// `/DSS`. No network fetching is performed.
+    pub revocation: RevocationStatus,
+}
+
+/// Offline certificate-revocation status, derived from CRLs embedded in the
+/// signature CMS or the document's `/DSS`. OCSP/CRL *fetching* over the network
+/// is out of scope (the project has no network dependency); this checks only
+/// the revocation material already embedded in the file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RevocationStatus {
+    /// No CRL was available to check against.
+    Unknown,
+    /// The signer certificate is not listed on any embedded CRL.
+    NotRevoked,
+    /// The signer certificate's serial appears on an embedded CRL.
+    Revoked,
 }
 
 impl Signature {
@@ -299,6 +326,18 @@ fn build_signature(file: &PdfFile, field_name: String, sig: &PdfDict) -> Signatu
     let coverage = parse_byte_range(file, sig, file.data().len());
     let outcome = verify(file, &coverage, contents.as_deref(), sub_filter.as_deref());
 
+    // Best-effort CMS analysis: timestamp detection, embedded cert count, and
+    // offline CRL revocation. `None` contents → all-default.
+    let (has_timestamp, cert_count, revocation) = match contents.as_deref() {
+        Some(cms) => (
+            revocation::has_timestamp(cms),
+            revocation::cert_count(cms),
+            revocation::revocation_status(cms),
+        ),
+        None => (false, 0, RevocationStatus::Unknown),
+    };
+    let has_dss = catalog_has_dss(file);
+
     Signature {
         field_name,
         filter: sig.get_name("Filter").ok().map(String::from),
@@ -315,7 +354,25 @@ fn build_signature(file: &PdfFile, field_name: String, sig: &PdfDict) -> Signatu
         signature_algorithm: outcome.signature_algorithm,
         signer_common_name: outcome.signer_common_name,
         cms_blob: contents,
+        has_timestamp,
+        cert_count,
+        has_dss,
+        revocation,
     }
+}
+
+/// Whether the catalog carries a `/DSS` (Document Security Store).
+fn catalog_has_dss(file: &PdfFile) -> bool {
+    let Ok(root) = file.trailer.get_ref("Root") else {
+        return false;
+    };
+    let Ok(catalog) = file.resolve(root).and_then(|o| o.as_dict().cloned()) else {
+        return false;
+    };
+    matches!(
+        deref(file, catalog.get("DSS").unwrap_or(&PdfObject::Null)),
+        PdfObject::Dict(_) | PdfObject::Ref(_)
+    )
 }
 
 /// The full result of verifying one signature's CMS blob.
@@ -1002,6 +1059,187 @@ fn text_string(file: &PdfFile, obj: &PdfObject) -> Option<String> {
     match deref(file, obj) {
         PdfObject::String(s) => Some(pdf_string_to_unicode(s.as_bytes())),
         _ => None,
+    }
+}
+
+/// Best-effort CMS analysis for production-grade signing: timestamp
+/// detection, embedded certificate count, and offline CRL revocation. All
+/// pure-DER byte walks over the `cms_blob`; no network, no crypto verification
+/// of the TSA or CRL signatures (the material is trusted as embedded).
+mod revocation {
+    use super::RevocationStatus;
+
+    /// OID for the CMS `signature-time-stamp` attribute (1.2.840.113549.1.9.16.2.14).
+    const OID_TIMESTAMP: &[u8] = &[
+        0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x09, 0x10, 0x02, 0x0e,
+    ];
+
+    /// True when the CMS carries a `signature-time-stamp` unsigned attribute.
+    pub fn has_timestamp(cms: &[u8]) -> bool {
+        cms.windows(OID_TIMESTAMP.len()).any(|w| w == OID_TIMESTAMP)
+    }
+
+    /// Count the certificates in the CMS `certificates [0]` set (best-effort).
+    pub fn cert_count(cms: &[u8]) -> usize {
+        match signed_data(cms) {
+            Some(sd) => match field(sd, 0xA0) {
+                Some(certs_blob) => children(certs_blob).len(),
+                None => 0,
+            },
+            None => 0,
+        }
+    }
+
+    /// Offline revocation: parse CRLs from `crls [1]`, collect their revoked
+    /// serials, and compare to the signer cert's serial (the first cert in
+    /// `certificates [0]`). `Unknown` when there are no CRLs or the serials
+    /// cannot be extracted.
+    pub fn revocation_status(cms: &[u8]) -> RevocationStatus {
+        let Some(sd) = signed_data(cms) else {
+            return RevocationStatus::Unknown;
+        };
+        let crls_blob = match field(sd, 0xA1) {
+            Some(b) => b,
+            None => return RevocationStatus::Unknown, // no CRLs embedded
+        };
+        let crls = children(crls_blob);
+        if crls.is_empty() {
+            return RevocationStatus::Unknown;
+        }
+        // Signer cert serial = first cert's serial.
+        let signer_serial = field(sd, 0xA0)
+            .and_then(|certs| children(certs).into_iter().next())
+            .and_then(cert_serial);
+        let Some(signer_serial) = signer_serial else {
+            return RevocationStatus::Unknown;
+        };
+        for crl in crls {
+            for revoked in crl_revoked_serials(crl) {
+                if revoked == signer_serial {
+                    return RevocationStatus::Revoked;
+                }
+            }
+        }
+        RevocationStatus::NotRevoked
+    }
+
+    /// (tag, content, rest-after-this-TLV) of the DER TLV at the start.
+    fn tlv_split(bytes: &[u8]) -> Option<(u8, &[u8], &[u8])> {
+        let &tag = bytes.first()?;
+        let len_byte = *bytes.get(1)?;
+        let (len, hdr) = if len_byte < 0x80 {
+            (len_byte as usize, 2)
+        } else {
+            let n = (len_byte & 0x7f) as usize;
+            if !(1..=4).contains(&n) || bytes.len() < 2 + n {
+                return None;
+            }
+            let mut l = 0usize;
+            for i in 0..n {
+                l = (l << 8) | bytes[2 + i] as usize;
+            }
+            (l, 2 + n)
+        };
+        let content = bytes.get(hdr..hdr + len)?;
+        Some((tag, content, &bytes[hdr + len..]))
+    }
+
+    /// Top-level TLV byte slices within `content`.
+    fn children(content: &[u8]) -> Vec<&[u8]> {
+        let mut out = Vec::new();
+        let mut rest = content;
+        while let Some((_, _, next)) = tlv_split(rest) {
+            let total = rest.len() - next.len();
+            out.push(&rest[..total]);
+            rest = next;
+        }
+        out
+    }
+
+    /// The SignedData content (the inner of ContentInfo's `[0]`), or `None`.
+    fn signed_data(cms: &[u8]) -> Option<&[u8]> {
+        // ContentInfo ::= SEQUENCE { OID, [0] SignedData }
+        let (_, outer, _) = tlv_split(cms)?;
+        let kids = children(outer);
+        kids.into_iter().find_map(|k| {
+            let (tag, content, _) = tlv_split(k)?;
+            (tag == 0xA0).then_some(content)
+        })
+    }
+
+    /// The content of the `[ctx_tag]` IMPLICIT field within a SignedData, if present.
+    fn field(sd: &[u8], ctx_tag: u8) -> Option<&[u8]> {
+        let (_, content, _) = tlv_split(sd)?;
+        for k in children(content) {
+            let (tag, c, _) = tlv_split(k)?;
+            if tag == ctx_tag {
+                return Some(c);
+            }
+        }
+        None
+    }
+
+    /// The serial number bytes of a certificate (DER), if parseable.
+    fn cert_serial(cert: &[u8]) -> Option<Vec<u8>> {
+        // Certificate ::= SEQUENCE { tbsCertificate SEQUENCE, ... }
+        let (_, tbs, _) = tlv_split(cert)?;
+        let (_, tbs_content, _) = tlv_split(tbs)?;
+        let mut kids = children(tbs_content).into_iter();
+        // tbsCertificate: [version [0]]?, serialNumber INT, ...
+        let first = kids.next()?;
+        let (tag, _content, _) = tlv_split(first)?;
+        let serial_field = if tag == 0xA0 {
+            // version present; serial is next.
+            kids.next()?
+        } else {
+            first
+        };
+        let (st, sc, _) = tlv_split(serial_field)?;
+        (st == 0x02).then_some(sc.to_vec())
+    }
+
+    /// Revoked serials from a CRL (CertificateList), if it carries revokedCertificates.
+    fn crl_revoked_serials(crl: &[u8]) -> Vec<Vec<u8>> {
+        // CertificateList ::= SEQUENCE { tbsCertList SEQ, ... }
+        let (_, tbs, _) = match tlv_split(crl) {
+            Some(x) => x,
+            None => return Vec::new(),
+        };
+        let (_, tbs_content, _) = match tlv_split(tbs) {
+            Some(x) => x,
+            None => return Vec::new(),
+        };
+        // tbsCertList: version? INT, signature SEQ, issuer SEQ, thisUpdate Time,
+        // nextUpdate? Time, revokedCertificates? SEQ OF, extensions? [0].
+        let mut out = Vec::new();
+        let mut seen_time = false;
+        for k in children(tbs_content) {
+            let (tag, content, _) = match tlv_split(k) {
+                Some(x) => x,
+                None => continue,
+            };
+            if tag == 0x17 || tag == 0x18 {
+                // UTCTime / GeneralizedTime
+                seen_time = true;
+                continue;
+            }
+            if tag == 0x30 && seen_time {
+                // revokedCertificates: SEQUENCE OF SEQUENCE { serial INT, ... }
+                for entry in children(content) {
+                    if let Some((_, ec, _)) = tlv_split(entry) {
+                        if let Some(serial_tlv) = children(ec).into_iter().next() {
+                            if let Some((st, sc, _)) = tlv_split(serial_tlv) {
+                                if st == 0x02 {
+                                    out.push(sc.to_vec());
+                                }
+                            }
+                        }
+                    }
+                }
+                break;
+            }
+        }
+        out
     }
 }
 

--- a/crates/zpdf-writer/Cargo.toml
+++ b/crates/zpdf-writer/Cargo.toml
@@ -31,6 +31,14 @@ p256 = { workspace = true, features = ["pkcs8"] }
 aes.workspace = true
 cbc = { workspace = true, features = ["alloc"] }
 getrandom = "0.2"
+# Optional RFC 3161 timestamp requester (pure-Rust HTTP via ureq + rustls).
+ureq = { workspace = true, optional = true }
+
+[features]
+# Enables the built-in `UreqTimestampRequester` (pure-Rust HTTP to a TSA URL).
+# Without it, the signing API still accepts a caller-supplied
+# `TimestampRequester` — the library has no network dependency by default.
+timestamp = ["dep:ureq"]
 
 [dev-dependencies]
 # Deterministic RSA keygen for the signing round-trip tests.

--- a/crates/zpdf-writer/Cargo.toml
+++ b/crates/zpdf-writer/Cargo.toml
@@ -35,3 +35,5 @@ getrandom = "0.2"
 [dev-dependencies]
 # Deterministic RSA keygen for the signing round-trip tests.
 rand_chacha = "0.3"
+# ToUnicode CMap round-trip validation in the CJK authoring tests.
+zpdf-font.workspace = true

--- a/crates/zpdf-writer/src/builder.rs
+++ b/crates/zpdf-writer/src/builder.rs
@@ -15,7 +15,7 @@
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use zpdf_core::{ObjectId, PdfDict, PdfName, PdfObject, Result};
 use zpdf_document::escape_text;
@@ -126,19 +126,41 @@ struct PageState {
     items: Vec<PageItem>,
 }
 
-/// An embedded TrueType font, parsed once at `embed_font` time.
+/// The embedding kind — a simple WinAnsi TrueType font (the original path)
+/// or a composite Type0/Identity-H font (CJK-capable, TrueType- or
+/// CFF-flavored).
+#[allow(clippy::large_enum_variant)] // WinAnsi carries a 256-entry width table; fonts are few.
+enum EmbeddedKind {
+    /// Simple-font TrueType with a WinAnsiEncoding byte width table.
+    WinAnsi { widths: [u16; 256] },
+    /// Composite (Type0) font using Identity-H (the 2-byte code is the GID).
+    Composite { program: FontProgram },
+}
+
+/// The font-program flavor, which decides `/FontFile2` vs `/FontFile3` and
+/// the descendant `/Subtype` (`CIDFontType2` vs `CIDFontType0`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FontProgram {
+    /// TrueType outlines (`glyf`/`loca`) — `/FontFile2`, `CIDFontType2`.
+    TrueType,
+    /// CFF outlines (an OTF `CFF ` table or raw CFF) — `/FontFile3 /OpenType`,
+    /// `CIDFontType0`.
+    OpenTypeCff,
+}
+
+/// An embedded font, parsed once at `embed_font` / `embed_composite_font`
+/// time. The `kind` selects the emission path; `data` is the raw font bytes.
 struct EmbeddedFont {
     /// PostScript-style name used as /BaseFont.
     ps_name: String,
-    /// The raw font file (embedded verbatim as FontFile2).
+    /// The raw font file (embedded, optionally subset, as FontFile2/3).
     data: Vec<u8>,
-    /// WinAnsi code → advance width in 1/1000 em units.
-    widths: [u16; 256],
     ascent: f64,
     descent: f64,
     cap_height: f64,
     bbox: [f64; 4],
     italic_angle: f64,
+    kind: EmbeddedKind,
 }
 
 /// A handle to an embedded font, returned by [`DocumentBuilder::embed_font`].
@@ -232,12 +254,98 @@ impl DocumentBuilder {
         self.embedded_fonts.push(EmbeddedFont {
             ps_name,
             data: font_bytes,
-            widths,
             ascent,
             descent,
             cap_height,
             bbox,
             italic_angle,
+            kind: EmbeddedKind::WinAnsi { widths },
+        });
+        Ok(EmbeddedFontHandle((self.embedded_fonts.len() - 1) as u32))
+    }
+
+    /// Embed a composite (Type0) font for CJK and other large glyph sets,
+    /// using **Identity-H**: the 2-byte code emitted in the content stream is
+    /// the glyph ID, and `/CIDToGIDMap /Identity` makes CID = GID. Text is
+    /// not limited to WinAnsi — any character the font's cmap can map is
+    /// encodable, including tens of thousands of CJK ideographs.
+    ///
+    /// Both TrueType-flavored (`glyf`, embedded as `/FontFile2` /
+    /// `CIDFontType2`) and CFF-flavored (OTF `CFF ` table or raw CFF,
+    /// embedded as `/FontFile3 /OpenType` / `CIDFontType0`) fonts are
+    /// supported. Raw CFF is wrapped in a minimal OTF container on embed.
+    /// Glyphs are subset at `build()` time (sparse glyf / sparse charstrings).
+    pub fn embed_composite_font(&mut self, font_bytes: Vec<u8>) -> Result<EmbeddedFontHandle> {
+        let (program, data) = if crate::cff::is_raw_cff(&font_bytes) {
+            let otf = crate::cff::wrap_cff_in_otf(&font_bytes);
+            if otf.is_empty() {
+                return Err(zpdf_core::Error::Io(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "cannot wrap raw CFF font into an OTF container",
+                )));
+            }
+            (FontProgram::OpenTypeCff, otf)
+        } else if crate::cff::is_cff_flavored(&font_bytes) {
+            (FontProgram::OpenTypeCff, font_bytes)
+        } else {
+            (FontProgram::TrueType, font_bytes)
+        };
+
+        let (ps_name, ascent, descent, cap_height, bbox, italic_angle) = {
+            let face = ttf_parser::Face::parse(&data, 0).map_err(|e| {
+                zpdf_core::Error::Io(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("cannot parse composite font: {e}"),
+                ))
+            })?;
+            let units_per_em = face.units_per_em() as f64;
+            if units_per_em <= 0.0 {
+                return Err(zpdf_core::Error::Io(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "composite font has invalid unitsPerEm",
+                )));
+            }
+            let to_milli = 1000.0 / units_per_em;
+            let ps_name = face
+                .names()
+                .into_iter()
+                .find(|n| n.name_id == ttf_parser::name_id::POST_SCRIPT_NAME)
+                .and_then(|n| n.to_string())
+                .or_else(|| {
+                    face.names()
+                        .into_iter()
+                        .find(|n| n.name_id == ttf_parser::name_id::FULL_NAME)
+                        .and_then(|n| n.to_string())
+                })
+                .unwrap_or_else(|| format!("ZPDFComposite{}", self.embedded_fonts.len()))
+                .replace(' ', "");
+            let bbox = face.global_bounding_box();
+            (
+                ps_name,
+                face.ascender() as f64 * to_milli,
+                face.descender() as f64 * to_milli,
+                face.capital_height()
+                    .map(|h| h as f64 * to_milli)
+                    .unwrap_or(700.0),
+                [
+                    bbox.x_min as f64 * to_milli,
+                    bbox.y_min as f64 * to_milli,
+                    bbox.x_max as f64 * to_milli,
+                    bbox.y_max as f64 * to_milli,
+                ],
+                face.italic_angle() as f64,
+            )
+        };
+
+        self.embedded_fonts.push(EmbeddedFont {
+            ps_name,
+            data,
+            ascent,
+            descent,
+            cap_height,
+            bbox,
+            italic_angle,
+            kind: EmbeddedKind::Composite { program },
         });
         Ok(EmbeddedFontHandle((self.embedded_fonts.len() - 1) as u32))
     }
@@ -447,9 +555,19 @@ impl DocumentBuilder {
         let mut image_objects: Vec<(u32, ImageData)> = Vec::new();
         let mut image_counter = 0usize;
 
+        // For composite (Type0/Identity-H) embedded fonts, build a char→GID
+        // map for every character used with that font, so build_page_content
+        // can emit 2-byte GID codes. Parsed once per font here, reused across
+        // pages (the content stream is emitted in the page loop below).
+        let composite_glyph_maps = self.build_composite_glyph_maps();
+
         for (page_idx, page_state) in self.pages.iter().enumerate() {
-            let (content_bytes, font_names, image_refs) =
-                self.build_page_content(page_state, &mut image_counter, &mut obj_num)?;
+            let (content_bytes, font_names, image_refs) = self.build_page_content(
+                page_state,
+                &mut image_counter,
+                &mut obj_num,
+                &composite_glyph_maps,
+            )?;
 
             // Record image data for the allocated object numbers.
             let mut ref_iter = image_refs.iter();
@@ -499,10 +617,8 @@ impl DocumentBuilder {
             {
                 let font = &self.embedded_fonts[idx];
 
-                // Subset to the characters actually shown with this font
-                // (sparse-glyf: unused outlines dropped, metrics preserved).
-                // Fall back to the full file when subsetting isn't possible.
-                let used: std::collections::HashSet<char> = self
+                // Collect the characters shown with this font across all pages.
+                let used: HashSet<char> = self
                     .pages
                     .iter()
                     .flat_map(|p| &p.items)
@@ -514,86 +630,281 @@ impl DocumentBuilder {
                     })
                     .flatten()
                     .collect();
-                let subset = crate::subset::subset_truetype(&font.data, &used);
-                let file_bytes: &[u8] = subset.as_deref().unwrap_or(&font.data);
 
-                // FontFile2 stream.
-                let file_num = obj_num;
-                obj_num += 1;
-                let mut file_dict = PdfDict::new();
-                file_dict.insert(
-                    PdfName::new("Filter"),
-                    PdfObject::Name(PdfName::new("FlateDecode")),
-                );
-                file_dict.insert(
-                    PdfName::new("Length1"),
-                    PdfObject::Integer(file_bytes.len() as i64),
-                );
-                streams.push((file_num, file_dict, flate_compress(file_bytes)?));
+                match &font.kind {
+                    EmbeddedKind::WinAnsi { widths } => {
+                        // Sparse-glyf subset: unused outlines dropped, metrics
+                        // preserved. Fall back to the full file when subsetting
+                        // isn't possible.
+                        let subset = crate::subset::subset_truetype(&font.data, &used);
+                        let file_bytes: &[u8] = subset.as_deref().unwrap_or(&font.data);
 
-                // FontDescriptor.
-                let desc_num = obj_num;
-                obj_num += 1;
-                let mut desc = PdfDict::new();
-                desc.insert(
-                    PdfName::new("Type"),
-                    PdfObject::Name(PdfName::new("FontDescriptor")),
-                );
-                desc.insert(
-                    PdfName::new("FontName"),
-                    PdfObject::Name(PdfName::new(&font.ps_name)),
-                );
-                // Flags: bit 6 (Nonsymbolic).
-                desc.insert(PdfName::new("Flags"), PdfObject::Integer(32));
-                desc.insert(
-                    PdfName::new("FontBBox"),
-                    PdfObject::Array(font.bbox.iter().map(|&v| PdfObject::Real(v)).collect()),
-                );
-                desc.insert(
-                    PdfName::new("ItalicAngle"),
-                    PdfObject::Real(font.italic_angle),
-                );
-                desc.insert(PdfName::new("Ascent"), PdfObject::Real(font.ascent));
-                desc.insert(PdfName::new("Descent"), PdfObject::Real(font.descent));
-                desc.insert(PdfName::new("CapHeight"), PdfObject::Real(font.cap_height));
-                desc.insert(PdfName::new("StemV"), PdfObject::Integer(80));
-                desc.insert(
-                    PdfName::new("FontFile2"),
-                    PdfObject::Ref(ObjectId(file_num, 0)),
-                );
-                objects.push((desc_num, PdfObject::Dict(desc)));
+                        // FontFile2 stream.
+                        let file_num = obj_num;
+                        obj_num += 1;
+                        let mut file_dict = PdfDict::new();
+                        file_dict.insert(
+                            PdfName::new("Filter"),
+                            PdfObject::Name(PdfName::new("FlateDecode")),
+                        );
+                        file_dict.insert(
+                            PdfName::new("Length1"),
+                            PdfObject::Integer(file_bytes.len() as i64),
+                        );
+                        streams.push((file_num, file_dict, flate_compress(file_bytes)?));
 
-                // Font dict (simple TrueType, WinAnsi).
-                let mut font_dict = PdfDict::new();
-                font_dict.insert(PdfName::new("Type"), PdfObject::Name(PdfName::new("Font")));
-                font_dict.insert(
-                    PdfName::new("Subtype"),
-                    PdfObject::Name(PdfName::new("TrueType")),
-                );
-                font_dict.insert(
-                    PdfName::new("BaseFont"),
-                    PdfObject::Name(PdfName::new(&font.ps_name)),
-                );
-                font_dict.insert(
-                    PdfName::new("Encoding"),
-                    PdfObject::Name(PdfName::new("WinAnsiEncoding")),
-                );
-                font_dict.insert(PdfName::new("FirstChar"), PdfObject::Integer(32));
-                font_dict.insert(PdfName::new("LastChar"), PdfObject::Integer(255));
-                font_dict.insert(
-                    PdfName::new("Widths"),
-                    PdfObject::Array(
-                        font.widths[32..=255]
-                            .iter()
-                            .map(|&w| PdfObject::Integer(w as i64))
-                            .collect(),
-                    ),
-                );
-                font_dict.insert(
-                    PdfName::new("FontDescriptor"),
-                    PdfObject::Ref(ObjectId(desc_num, 0)),
-                );
-                objects.push((*num, PdfObject::Dict(font_dict)));
+                        // FontDescriptor.
+                        let desc_num = obj_num;
+                        obj_num += 1;
+                        let mut desc = PdfDict::new();
+                        desc.insert(
+                            PdfName::new("Type"),
+                            PdfObject::Name(PdfName::new("FontDescriptor")),
+                        );
+                        desc.insert(
+                            PdfName::new("FontName"),
+                            PdfObject::Name(PdfName::new(&font.ps_name)),
+                        );
+                        // Flags: bit 6 (Nonsymbolic).
+                        desc.insert(PdfName::new("Flags"), PdfObject::Integer(32));
+                        desc.insert(
+                            PdfName::new("FontBBox"),
+                            PdfObject::Array(
+                                font.bbox.iter().map(|&v| PdfObject::Real(v)).collect(),
+                            ),
+                        );
+                        desc.insert(
+                            PdfName::new("ItalicAngle"),
+                            PdfObject::Real(font.italic_angle),
+                        );
+                        desc.insert(PdfName::new("Ascent"), PdfObject::Real(font.ascent));
+                        desc.insert(PdfName::new("Descent"), PdfObject::Real(font.descent));
+                        desc.insert(PdfName::new("CapHeight"), PdfObject::Real(font.cap_height));
+                        desc.insert(PdfName::new("StemV"), PdfObject::Integer(80));
+                        desc.insert(
+                            PdfName::new("FontFile2"),
+                            PdfObject::Ref(ObjectId(file_num, 0)),
+                        );
+                        objects.push((desc_num, PdfObject::Dict(desc)));
+
+                        // Font dict (simple TrueType, WinAnsi).
+                        let mut font_dict = PdfDict::new();
+                        font_dict
+                            .insert(PdfName::new("Type"), PdfObject::Name(PdfName::new("Font")));
+                        font_dict.insert(
+                            PdfName::new("Subtype"),
+                            PdfObject::Name(PdfName::new("TrueType")),
+                        );
+                        font_dict.insert(
+                            PdfName::new("BaseFont"),
+                            PdfObject::Name(PdfName::new(&font.ps_name)),
+                        );
+                        font_dict.insert(
+                            PdfName::new("Encoding"),
+                            PdfObject::Name(PdfName::new("WinAnsiEncoding")),
+                        );
+                        font_dict.insert(PdfName::new("FirstChar"), PdfObject::Integer(32));
+                        font_dict.insert(PdfName::new("LastChar"), PdfObject::Integer(255));
+                        font_dict.insert(
+                            PdfName::new("Widths"),
+                            PdfObject::Array(
+                                widths[32..=255]
+                                    .iter()
+                                    .map(|&w| PdfObject::Integer(w as i64))
+                                    .collect(),
+                            ),
+                        );
+                        font_dict.insert(
+                            PdfName::new("FontDescriptor"),
+                            PdfObject::Ref(ObjectId(desc_num, 0)),
+                        );
+                        objects.push((*num, PdfObject::Dict(font_dict)));
+                    }
+                    EmbeddedKind::Composite { program } => {
+                        // Type0 / Identity-H composite font. Resolve GIDs and
+                        // advance widths for the used characters, build the
+                        // sparse /W array and /ToUnicode pairs, and subset.
+                        let face = ttf_parser::Face::parse(&font.data, 0).map_err(|e| {
+                            zpdf_core::Error::Io(std::io::Error::new(
+                                std::io::ErrorKind::InvalidInput,
+                                format!("cannot parse composite font for emission: {e}"),
+                            ))
+                        })?;
+                        let upem = face.units_per_em() as f64;
+                        let to_milli = if upem > 0.0 { 1000.0 / upem } else { 1.0 };
+
+                        let mut keep_gids: HashSet<u16> = HashSet::new();
+                        keep_gids.insert(0); // .notdef
+                        let mut gid_entries: Vec<(u16, u16)> = Vec::new();
+                        let mut tounicode_pairs: Vec<(u16, char)> = Vec::new();
+                        for ch in &used {
+                            let gid = face.glyph_index(*ch).map(|g| g.0).unwrap_or(0);
+                            keep_gids.insert(gid);
+                            let w = face
+                                .glyph_hor_advance(ttf_parser::GlyphId(gid))
+                                .map(|a| (a as f64 * to_milli).round().max(0.0) as u16)
+                                .unwrap_or(1000);
+                            gid_entries.push((gid, w));
+                            tounicode_pairs.push((gid, *ch));
+                        }
+                        gid_entries.sort_unstable_by_key(|(g, _)| *g);
+                        gid_entries.dedup_by_key(|(g, _)| *g);
+                        let w_array = build_w_array(&gid_entries);
+
+                        // Subset (sparse glyf for TrueType, sparse charstrings
+                        // for CFF); fall back to the full font.
+                        let subset = match program {
+                            FontProgram::TrueType => {
+                                crate::subset::subset_truetype(&font.data, &used)
+                            }
+                            FontProgram::OpenTypeCff => {
+                                crate::cff::subset_cff(&font.data, &keep_gids)
+                            }
+                        };
+                        let file_bytes: &[u8] = subset.as_deref().unwrap_or(&font.data);
+
+                        // FontFile2 (TrueType) or FontFile3 /OpenType (CFF).
+                        let file_num = obj_num;
+                        obj_num += 1;
+                        let mut file_dict = PdfDict::new();
+                        file_dict.insert(
+                            PdfName::new("Filter"),
+                            PdfObject::Name(PdfName::new("FlateDecode")),
+                        );
+                        match program {
+                            FontProgram::TrueType => {
+                                file_dict.insert(
+                                    PdfName::new("Length1"),
+                                    PdfObject::Integer(file_bytes.len() as i64),
+                                );
+                            }
+                            FontProgram::OpenTypeCff => {
+                                file_dict.insert(
+                                    PdfName::new("Subtype"),
+                                    PdfObject::Name(PdfName::new("OpenType")),
+                                );
+                            }
+                        }
+                        streams.push((file_num, file_dict, flate_compress(file_bytes)?));
+
+                        // FontDescriptor.
+                        let desc_num = obj_num;
+                        obj_num += 1;
+                        let mut desc = PdfDict::new();
+                        desc.insert(
+                            PdfName::new("Type"),
+                            PdfObject::Name(PdfName::new("FontDescriptor")),
+                        );
+                        desc.insert(
+                            PdfName::new("FontName"),
+                            PdfObject::Name(PdfName::new(&font.ps_name)),
+                        );
+                        // Flags: bit 3 (Symbolic) — typical for Identity-H CJK.
+                        desc.insert(PdfName::new("Flags"), PdfObject::Integer(4));
+                        desc.insert(
+                            PdfName::new("FontBBox"),
+                            PdfObject::Array(
+                                font.bbox.iter().map(|&v| PdfObject::Real(v)).collect(),
+                            ),
+                        );
+                        desc.insert(
+                            PdfName::new("ItalicAngle"),
+                            PdfObject::Real(font.italic_angle),
+                        );
+                        desc.insert(PdfName::new("Ascent"), PdfObject::Real(font.ascent));
+                        desc.insert(PdfName::new("Descent"), PdfObject::Real(font.descent));
+                        desc.insert(PdfName::new("CapHeight"), PdfObject::Real(font.cap_height));
+                        desc.insert(PdfName::new("StemV"), PdfObject::Integer(80));
+                        match program {
+                            FontProgram::TrueType => desc.insert(
+                                PdfName::new("FontFile2"),
+                                PdfObject::Ref(ObjectId(file_num, 0)),
+                            ),
+                            FontProgram::OpenTypeCff => desc.insert(
+                                PdfName::new("FontFile3"),
+                                PdfObject::Ref(ObjectId(file_num, 0)),
+                            ),
+                        }
+                        objects.push((desc_num, PdfObject::Dict(desc)));
+
+                        // CIDFont descendant dict.
+                        let cid_num = obj_num;
+                        obj_num += 1;
+                        let mut cid = PdfDict::new();
+                        cid.insert(PdfName::new("Type"), PdfObject::Name(PdfName::new("Font")));
+                        cid.insert(
+                            PdfName::new("Subtype"),
+                            PdfObject::Name(PdfName::new(match program {
+                                FontProgram::TrueType => "CIDFontType2",
+                                FontProgram::OpenTypeCff => "CIDFontType0",
+                            })),
+                        );
+                        cid.insert(
+                            PdfName::new("BaseFont"),
+                            PdfObject::Name(PdfName::new(&font.ps_name)),
+                        );
+                        let mut sysinfo = PdfDict::new();
+                        sysinfo.insert(
+                            PdfName::new("Registry"),
+                            PdfObject::String(zpdf_core::PdfString(b"Adobe".to_vec())),
+                        );
+                        sysinfo.insert(
+                            PdfName::new("Ordering"),
+                            PdfObject::String(zpdf_core::PdfString(b"Identity".to_vec())),
+                        );
+                        sysinfo.insert(PdfName::new("Supplement"), PdfObject::Integer(0));
+                        cid.insert(PdfName::new("CIDSystemInfo"), PdfObject::Dict(sysinfo));
+                        cid.insert(
+                            PdfName::new("FontDescriptor"),
+                            PdfObject::Ref(ObjectId(desc_num, 0)),
+                        );
+                        cid.insert(PdfName::new("DW"), PdfObject::Integer(1000));
+                        cid.insert(PdfName::new("W"), w_array);
+                        cid.insert(
+                            PdfName::new("CIDToGIDMap"),
+                            PdfObject::Name(PdfName::new("Identity")),
+                        );
+                        objects.push((cid_num, PdfObject::Dict(cid)));
+
+                        // ToUnicode CMap stream.
+                        let tounicode_num = obj_num;
+                        obj_num += 1;
+                        let tounicode_bytes =
+                            crate::tounicode::build_tounicode_cmap(&tounicode_pairs);
+                        let mut tu_dict = PdfDict::new();
+                        tu_dict.insert(
+                            PdfName::new("Filter"),
+                            PdfObject::Name(PdfName::new("FlateDecode")),
+                        );
+                        streams.push((tounicode_num, tu_dict, flate_compress(&tounicode_bytes)?));
+
+                        // Type0 font dict (the font object itself).
+                        let mut font_dict = PdfDict::new();
+                        font_dict
+                            .insert(PdfName::new("Type"), PdfObject::Name(PdfName::new("Font")));
+                        font_dict.insert(
+                            PdfName::new("Subtype"),
+                            PdfObject::Name(PdfName::new("Type0")),
+                        );
+                        font_dict.insert(
+                            PdfName::new("BaseFont"),
+                            PdfObject::Name(PdfName::new(&font.ps_name)),
+                        );
+                        font_dict.insert(
+                            PdfName::new("Encoding"),
+                            PdfObject::Name(PdfName::new("Identity-H")),
+                        );
+                        font_dict.insert(
+                            PdfName::new("DescendantFonts"),
+                            PdfObject::Array(vec![PdfObject::Ref(ObjectId(cid_num, 0))]),
+                        );
+                        font_dict.insert(
+                            PdfName::new("ToUnicode"),
+                            PdfObject::Ref(ObjectId(tounicode_num, 0)),
+                        );
+                        objects.push((*num, PdfObject::Dict(font_dict)));
+                    }
+                }
             } else {
                 let mut font_dict = PdfDict::new();
                 font_dict.insert(PdfName::new("Type"), PdfObject::Name(PdfName::new("Font")));
@@ -829,11 +1140,54 @@ impl DocumentBuilder {
         Ok(out)
     }
 
+    /// For each composite (Type0/Identity-H) embedded font, parse the font
+    /// once and build a `char → GID` map covering every character used with
+    /// that font across all pages. Used by [`build_page_content`] to emit the
+    /// 2-byte GID codes that Identity-H addresses. Characters with no glyph
+    /// map to GID 0 (`.notdef`), which keeps text positioning stable.
+    fn build_composite_glyph_maps(&self) -> HashMap<u32, HashMap<char, u16>> {
+        let mut out: HashMap<u32, HashMap<char, u16>> = HashMap::new();
+        for (idx, font) in self.embedded_fonts.iter().enumerate() {
+            let EmbeddedKind::Composite { .. } = &font.kind else {
+                continue;
+            };
+            let marker = format!("\u{0}EMB{}", idx);
+            // Collect the characters used with this font on every page.
+            let used: HashSet<char> = self
+                .pages
+                .iter()
+                .flat_map(|p| &p.items)
+                .filter_map(|item| match item {
+                    PageItem::Text {
+                        text, font_name, ..
+                    } if font_name == &marker => Some(text.chars()),
+                    _ => None,
+                })
+                .flatten()
+                .collect();
+            if used.is_empty() {
+                out.insert(idx as u32, HashMap::new());
+                continue;
+            }
+            let Ok(face) = ttf_parser::Face::parse(&font.data, 0) else {
+                continue;
+            };
+            let mut map: HashMap<char, u16> = HashMap::with_capacity(used.len());
+            for ch in used {
+                let gid = face.glyph_index(ch).map(|g| g.0).unwrap_or(0);
+                map.insert(ch, gid);
+            }
+            out.insert(idx as u32, map);
+        }
+        out
+    }
+
     fn build_page_content(
         &self,
         page_state: &PageState,
         image_counter: &mut usize,
         next_obj: &mut u32,
+        composite_glyph_maps: &HashMap<u32, HashMap<char, u16>>,
     ) -> Result<(Vec<u8>, Vec<String>, Vec<u32>)> {
         let mut ops = Vec::new();
         let mut font_names = Vec::new();
@@ -870,9 +1224,25 @@ impl DocumentBuilder {
                     ops.extend_from_slice(format!("{} {} {} rg\n", r, g, b).as_bytes());
                     ops.extend_from_slice(format!("/F{} {} Tf\n", font_idx, size).as_bytes());
                     ops.extend_from_slice(format!("1 0 0 1 {} {} Tm\n", x, y).as_bytes());
-                    ops.extend_from_slice(b"(");
-                    escape_text(text, &mut ops);
-                    ops.extend_from_slice(b") Tj\n");
+                    // Composite (Type0/Identity-H) fonts emit 2-byte GID codes
+                    // as a hex string; simple/standard-14 fonts use a WinAnsi
+                    // literal string.
+                    let composite = font_name
+                        .strip_prefix("\u{0}EMB")
+                        .and_then(|s| s.parse::<u32>().ok())
+                        .and_then(|idx| composite_glyph_maps.get(&idx));
+                    if let Some(gmap) = composite {
+                        ops.extend_from_slice(b"<");
+                        for ch in text.chars() {
+                            let gid = gmap.get(&ch).copied().unwrap_or(0);
+                            ops.extend_from_slice(format!("{gid:04X}").as_bytes());
+                        }
+                        ops.extend_from_slice(b"> Tj\n");
+                    } else {
+                        ops.extend_from_slice(b"(");
+                        escape_text(text, &mut ops);
+                        ops.extend_from_slice(b") Tj\n");
+                    }
                 }
                 PageItem::Image {
                     image: _,
@@ -972,6 +1342,22 @@ impl Default for DocumentBuilder {
     }
 }
 
+/// Classify a font file's outline flavor as [`DocumentBuilder::embed_composite_font`]
+/// would: CFF (an OTF `CFF ` table or raw CFF) → [`FontProgram::OpenTypeCff`];
+/// a TrueType sfnt (`\x00\x01\x00\x00` / `true`) → [`FontProgram::TrueType`].
+/// Returns `None` for an unrecognized format. Useful for tests and callers
+/// that want to predict the descendant `/Subtype` (`CIDFontType0` vs
+/// `CIDFontType2`) before embedding.
+pub fn classify_font_program(font: &[u8]) -> Option<FontProgram> {
+    if crate::cff::is_cff_flavored(font) {
+        Some(FontProgram::OpenTypeCff)
+    } else if font.starts_with(&[0x00, 0x01, 0x00, 0x00]) || font.starts_with(b"true") {
+        Some(FontProgram::TrueType)
+    } else {
+        None
+    }
+}
+
 /// WinAnsiEncoding (CP1252) code → Unicode char. Latin-1 except 0x80–0x9F.
 fn winansi_code_to_char(code: u8) -> Option<char> {
     match code {
@@ -1005,6 +1391,29 @@ fn winansi_code_to_char(code: u8) -> Option<char> {
         0x81 | 0x8D | 0x8F | 0x90 | 0x9D => None,
         _ => Some(code as char),
     }
+}
+
+/// Build a CIDFont `/W` array from sorted `(gid, width)` entries: runs of
+/// consecutive GIDs become `first [w1 w2 …]` pairs (the compact form the read
+/// side parses via `parse_cid_widths`). Single entries are a one-element run.
+fn build_w_array(entries: &[(u16, u16)]) -> PdfObject {
+    let mut arr: Vec<PdfObject> = Vec::new();
+    let mut i = 0;
+    while i < entries.len() {
+        let first = entries[i].0;
+        let mut j = i + 1;
+        while j < entries.len() && entries[j].0 == entries[j - 1].0 + 1 {
+            j += 1;
+        }
+        let widths: Vec<PdfObject> = entries[i..j]
+            .iter()
+            .map(|(_, w)| PdfObject::Integer(*w as i64))
+            .collect();
+        arr.push(PdfObject::Integer(first as i64));
+        arr.push(PdfObject::Array(widths));
+        i = j;
+    }
+    PdfObject::Array(arr)
 }
 
 fn image_xobject_dict(width: u32, height: u32, color_space: &str) -> PdfDict {

--- a/crates/zpdf-writer/src/builder.rs
+++ b/crates/zpdf-writer/src/builder.rs
@@ -20,6 +20,8 @@ use std::collections::{HashMap, HashSet};
 use zpdf_core::{ObjectId, PdfDict, PdfName, PdfObject, Result};
 use zpdf_document::escape_text;
 
+use crate::metadata::encode_text_string;
+
 /// A handle to a page.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct PageHandle(u32);
@@ -48,6 +50,21 @@ pub enum ImageData {
     },
 }
 
+/// A structure-element tag for a page item: the role (`/S`) and optional
+/// accessibility text (`/Alt`, `/ActualText`). When present, the item's
+/// painting operators are wrapped in a marked-content sequence
+/// (`/Role << /MCID N >> BDC … EMC`) and a matching `/StructElem` is emitted
+/// in the document's `/StructTreeRoot` — producing a Tagged PDF.
+#[derive(Debug, Clone)]
+pub struct TagSpec {
+    /// The structure role (`/S`), e.g. `P`, `H1`, `Figure`.
+    pub role: zpdf_document::StructRole,
+    /// `/Alt` — an alternate textual description (required for `Figure`).
+    pub alt: Option<String>,
+    /// `/ActualText` — the exact replacement text for the item.
+    pub actual_text: Option<String>,
+}
+
 /// Item to place on a page.
 enum PageItem {
     Text {
@@ -57,6 +74,7 @@ enum PageItem {
         font_name: String,
         size: f64,
         color: (f64, f64, f64),
+        tag: Option<TagSpec>,
     },
     Image {
         image: ImageData,
@@ -64,10 +82,12 @@ enum PageItem {
         y: f64,
         width: f64,
         height: f64,
+        tag: Option<TagSpec>,
     },
     Path {
         segments: Vec<PathSegment>,
         style: PathStyle,
+        tag: Option<TagSpec>,
     },
 }
 
@@ -171,6 +191,8 @@ pub struct EmbeddedFontHandle(u32);
 pub struct DocumentBuilder {
     pages: Vec<PageState>,
     embedded_fonts: Vec<EmbeddedFont>,
+    /// Catalog `/Lang` (BCP 47), written when the document is tagged.
+    lang: Option<String>,
 }
 
 impl DocumentBuilder {
@@ -179,7 +201,15 @@ impl DocumentBuilder {
         Self {
             pages: Vec::new(),
             embedded_fonts: Vec::new(),
+            lang: None,
         }
+    }
+
+    /// Set the catalog `/Lang` (a BCP 47 language tag), emitted when the
+    /// document is built. Required for PDF/UA and good practice for Tagged
+    /// PDFs (it scopes the document's natural language for screen readers).
+    pub fn set_lang(&mut self, lang: impl Into<String>) {
+        self.lang = Some(lang.into());
     }
 
     /// Embed a TrueType font. The returned handle is used with
@@ -379,6 +409,7 @@ impl DocumentBuilder {
                 font_name: marker,
                 size,
                 color,
+                tag: None,
             });
             Ok(())
         } else {
@@ -449,6 +480,7 @@ impl DocumentBuilder {
                 font_name: normalized,
                 size,
                 color,
+                tag: None,
             });
             Ok(())
         } else {
@@ -476,6 +508,7 @@ impl DocumentBuilder {
                 y,
                 width,
                 height,
+                tag: None,
             });
             Ok(())
         } else {
@@ -520,7 +553,11 @@ impl DocumentBuilder {
             )));
         }
         if let Some(page_state) = self.pages.get_mut(page.0 as usize) {
-            page_state.items.push(PageItem::Path { segments, style });
+            page_state.items.push(PageItem::Path {
+                segments,
+                style,
+                tag: None,
+            });
             Ok(())
         } else {
             Err(zpdf_core::Error::Io(std::io::Error::new(
@@ -528,6 +565,111 @@ impl DocumentBuilder {
                 "page handle not found",
             )))
         }
+    }
+
+    /// Add tagged text using a previously embedded font. The text is wrapped
+    /// in a marked-content sequence carrying `tag.role` and an MCID, and a
+    /// matching `/StructElem` is emitted in the `/StructTreeRoot` at build
+    /// time — producing Tagged PDF content.
+    #[allow(clippy::too_many_arguments)]
+    pub fn add_tagged_text_embedded(
+        &mut self,
+        page: PageHandle,
+        text: &str,
+        x: f64,
+        y: f64,
+        font: EmbeddedFontHandle,
+        size: f64,
+        color: (f64, f64, f64),
+        tag: TagSpec,
+    ) -> Result<()> {
+        if font.0 as usize >= self.embedded_fonts.len() {
+            return Err(zpdf_core::Error::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "embedded font handle not found",
+            )));
+        }
+        let marker = format!("\u{0}EMB{}", font.0);
+        if let Some(page_state) = self.pages.get_mut(page.0 as usize) {
+            page_state.items.push(PageItem::Text {
+                text: text.to_string(),
+                x,
+                y,
+                font_name: marker,
+                size,
+                color,
+                tag: Some(tag),
+            });
+            Ok(())
+        } else {
+            Err(zpdf_core::Error::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "page handle not found",
+            )))
+        }
+    }
+
+    /// Add tagged text using a standard-14 font. See
+    /// [`Self::add_tagged_text_embedded`].
+    #[allow(clippy::too_many_arguments)]
+    pub fn add_tagged_text(
+        &mut self,
+        page: PageHandle,
+        text: &str,
+        x: f64,
+        y: f64,
+        font_name: &str,
+        size: f64,
+        color: (f64, f64, f64),
+        tag: TagSpec,
+    ) -> Result<()> {
+        // Reuse the standard-14 validation in add_text by calling it, then
+        // patch in the tag.
+        self.add_text(page, text, x, y, font_name, size, color)?;
+        if let Some(page_state) = self.pages.get_mut(page.0 as usize) {
+            if let Some(PageItem::Text { tag: slot, .. }) = page_state.items.last_mut() {
+                *slot = Some(tag);
+            }
+        }
+        Ok(())
+    }
+
+    /// Add a tagged image. See [`Self::add_tagged_text_embedded`].
+    #[allow(clippy::too_many_arguments)]
+    pub fn add_tagged_image(
+        &mut self,
+        page: PageHandle,
+        image: ImageData,
+        x: f64,
+        y: f64,
+        width: f64,
+        height: f64,
+        tag: TagSpec,
+    ) -> Result<()> {
+        self.add_image(page, image, x, y, width, height)?;
+        if let Some(page_state) = self.pages.get_mut(page.0 as usize) {
+            if let Some(PageItem::Image { tag: slot, .. }) = page_state.items.last_mut() {
+                *slot = Some(tag);
+            }
+        }
+        Ok(())
+    }
+
+    /// Add a tagged vector path. See [`Self::add_tagged_text_embedded`].
+    pub fn add_tagged_path(
+        &mut self,
+        page: PageHandle,
+        segments: Vec<PathSegment>,
+        style: PathStyle,
+        tag: TagSpec,
+    ) -> Result<()> {
+        self.add_path(page, segments, style)?;
+        if let Some(page_state) = self.pages.get_mut(page.0 as usize) {
+            if let Some(PageItem::Path { tag: slot, .. }) = page_state.items.last_mut() {
+                *slot = Some(tag);
+            }
+        }
+        Ok(())
     }
 
     /// Build the PDF and return its bytes.
@@ -562,7 +704,7 @@ impl DocumentBuilder {
         let composite_glyph_maps = self.build_composite_glyph_maps();
 
         for (page_idx, page_state) in self.pages.iter().enumerate() {
-            let (content_bytes, font_names, image_refs) = self.build_page_content(
+            let (content_bytes, font_names, image_refs, tagged) = self.build_page_content(
                 page_state,
                 &mut image_counter,
                 &mut obj_num,
@@ -588,6 +730,7 @@ impl DocumentBuilder {
                 content_bytes,
                 font_names,
                 image_refs,
+                tagged,
             ));
         }
 
@@ -595,7 +738,7 @@ impl DocumentBuilder {
         // zpdf's own resource loader, only follow /Font entries that are
         // references). Dedup per document by BaseFont name.
         let mut font_obj_by_name: HashMap<String, u32> = HashMap::new();
-        for (_, _, _, font_names, _) in &page_contents {
+        for (_, _, _, font_names, _, _) in &page_contents {
             for name in font_names {
                 if !font_obj_by_name.contains_key(name) {
                     font_obj_by_name.insert(name.clone(), obj_num);
@@ -920,6 +1063,98 @@ impl DocumentBuilder {
             }
         }
 
+        // --- Tagged PDF: when any page carries tagged items, emit a
+        // /StructTreeRoot + /MarkInfo (and /Lang when set). Each tagged item
+        // becomes a /StructElem with /K = its MCID; the root /ParentTree maps
+        // each page's /StructParents key to that page's elem-ref array (in
+        // MCID order), so the read side can resolve MCID → element.
+        let any_tagged = page_contents
+            .iter()
+            .any(|(_, _, _, _, _, tagged)| !tagged.is_empty());
+        let tree_root_num: Option<u32> = if any_tagged {
+            // Reserve the StructTreeRoot number first so every /StructElem's
+            // /P can point back at it.
+            let tree_root_num = obj_num;
+            obj_num += 1;
+
+            let mut top_level_elems: Vec<PdfObject> = Vec::new();
+            let mut parent_nums: Vec<PdfObject> = Vec::new();
+            for (page_idx, (page_num, _, _, _, _, tagged)) in page_contents.iter().enumerate() {
+                if tagged.is_empty() {
+                    continue;
+                }
+                let mut elem_refs: Vec<PdfObject> = Vec::with_capacity(tagged.len());
+                for (mcid, spec) in tagged {
+                    let elem_num = obj_num;
+                    obj_num += 1;
+                    elem_refs.push(PdfObject::Ref(ObjectId(elem_num, 0)));
+                    let mut elem = PdfDict::new();
+                    elem.insert(
+                        PdfName::new("Type"),
+                        PdfObject::Name(PdfName::new("StructElem")),
+                    );
+                    elem.insert(
+                        PdfName::new("S"),
+                        PdfObject::Name(PdfName::new(spec.role.as_str())),
+                    );
+                    elem.insert(
+                        PdfName::new("P"),
+                        PdfObject::Ref(ObjectId(tree_root_num, 0)),
+                    );
+                    elem.insert(PdfName::new("Pg"), PdfObject::Ref(ObjectId(*page_num, 0)));
+                    elem.insert(PdfName::new("K"), PdfObject::Integer(*mcid as i64));
+                    if let Some(alt) = &spec.alt {
+                        elem.insert(
+                            PdfName::new("Alt"),
+                            PdfObject::String(encode_text_string(alt)),
+                        );
+                    }
+                    if let Some(actual) = &spec.actual_text {
+                        elem.insert(
+                            PdfName::new("ActualText"),
+                            PdfObject::String(encode_text_string(actual)),
+                        );
+                    }
+                    objects.push((elem_num, PdfObject::Dict(elem)));
+                }
+                top_level_elems.extend(elem_refs.iter().cloned());
+
+                // The parent-tree array for this page (elem refs in MCID order).
+                let arr_num = obj_num;
+                obj_num += 1;
+                objects.push((arr_num, PdfObject::Array(elem_refs)));
+                parent_nums.push(PdfObject::Integer(page_idx as i64));
+                parent_nums.push(PdfObject::Ref(ObjectId(arr_num, 0)));
+            }
+
+            // /ParentTree number tree: /Nums [ key0 arr0 key1 arr1 … ].
+            let parent_tree_num = obj_num;
+            obj_num += 1;
+            let mut parent_tree = PdfDict::new();
+            parent_tree.insert(PdfName::new("Nums"), PdfObject::Array(parent_nums));
+            objects.push((parent_tree_num, PdfObject::Dict(parent_tree)));
+
+            // StructTreeRoot.
+            let mut root = PdfDict::new();
+            root.insert(
+                PdfName::new("Type"),
+                PdfObject::Name(PdfName::new("StructTreeRoot")),
+            );
+            root.insert(PdfName::new("K"), PdfObject::Array(top_level_elems));
+            root.insert(
+                PdfName::new("ParentTree"),
+                PdfObject::Ref(ObjectId(parent_tree_num, 0)),
+            );
+            root.insert(
+                PdfName::new("ParentTreeNextKey"),
+                PdfObject::Integer(num_pages as i64),
+            );
+            objects.push((tree_root_num, PdfObject::Dict(root)));
+            Some(tree_root_num)
+        } else {
+            None
+        };
+
         // Object 1: Catalog
         let mut catalog = PdfDict::new();
         catalog.insert(
@@ -927,6 +1162,21 @@ impl DocumentBuilder {
             PdfObject::Name(PdfName::new("Catalog")),
         );
         catalog.insert(PdfName::new("Pages"), PdfObject::Ref(ObjectId(2, 0)));
+        if let Some(tree_num) = tree_root_num {
+            catalog.insert(
+                PdfName::new("StructTreeRoot"),
+                PdfObject::Ref(ObjectId(tree_num, 0)),
+            );
+            let mut mark_info = PdfDict::new();
+            mark_info.insert(PdfName::new("Marked"), PdfObject::Bool(true));
+            catalog.insert(PdfName::new("MarkInfo"), PdfObject::Dict(mark_info));
+        }
+        if let Some(lang) = &self.lang {
+            catalog.insert(
+                PdfName::new("Lang"),
+                PdfObject::String(encode_text_string(lang)),
+            );
+        }
         objects.push((1u32, PdfObject::Dict(catalog)));
 
         // Object 2: Pages tree
@@ -941,7 +1191,10 @@ impl DocumentBuilder {
         objects.push((2u32, PdfObject::Dict(pages_tree)));
 
         // Pages and their content streams
-        for (page_num, content_num, content_bytes, font_names, image_refs) in page_contents {
+        for (page_num, content_num, content_bytes, font_names, image_refs, tagged) in &page_contents
+        {
+            let page_num = *page_num;
+            let content_num = *content_num;
             let page_state = &self.pages[(page_num - 3) as usize];
 
             // Page dict
@@ -961,6 +1214,13 @@ impl DocumentBuilder {
                 PdfName::new("Contents"),
                 PdfObject::Ref(ObjectId(content_num, 0)),
             );
+            if !tagged.is_empty() {
+                // The page's key into the /ParentTree /Nums is its 0-based index.
+                page.insert(
+                    PdfName::new("StructParents"),
+                    PdfObject::Integer((page_num - 3) as i64),
+                );
+            }
 
             // Resources dict
             if !font_names.is_empty() || !image_refs.is_empty() {
@@ -1000,7 +1260,7 @@ impl DocumentBuilder {
                 PdfName::new("Filter"),
                 PdfObject::Name(PdfName::new("FlateDecode")),
             );
-            let compressed = flate_compress(&content_bytes)?;
+            let compressed = flate_compress(content_bytes)?;
             streams.push((content_num, content_dict, compressed));
         }
 
@@ -1182,18 +1442,26 @@ impl DocumentBuilder {
         out
     }
 
+    #[allow(clippy::type_complexity)] // flat build tuple; factoring a type alias would obscure it
     fn build_page_content(
         &self,
         page_state: &PageState,
         image_counter: &mut usize,
         next_obj: &mut u32,
         composite_glyph_maps: &HashMap<u32, HashMap<char, u16>>,
-    ) -> Result<(Vec<u8>, Vec<String>, Vec<u32>)> {
+    ) -> Result<(Vec<u8>, Vec<String>, Vec<u32>, Vec<(i32, TagSpec)>)> {
         let mut ops = Vec::new();
         let mut font_names = Vec::new();
         let mut image_refs = Vec::new();
         let mut used_fonts = HashMap::new();
         let mut used_images = HashMap::new();
+        // Per-page marked-content identifiers for tagged items, assigned in
+        // item order (0, 1, 2, …). The /StructTreeRoot's /ParentTree maps each
+        // page's /StructParents key to an array of /StructElem refs indexed by
+        // MCID, so the order here must match the order the struct elements are
+        // emitted in build().
+        let mut next_mcid: i32 = 0;
+        let mut tagged: Vec<(i32, TagSpec)> = Vec::new();
 
         ops.extend_from_slice(b"BT\n");
 
@@ -1206,6 +1474,7 @@ impl DocumentBuilder {
                     font_name,
                     size,
                     color,
+                    tag,
                 } => {
                     // Ensure font is in the resources
                     let font_idx = if let Some(&idx) = used_fonts.get(font_name) {
@@ -1216,6 +1485,15 @@ impl DocumentBuilder {
                         font_names.push(font_name.clone());
                         idx
                     };
+
+                    if let Some(spec) = tag {
+                        let mcid = next_mcid;
+                        next_mcid += 1;
+                        tagged.push((mcid, spec.clone()));
+                        ops.extend_from_slice(
+                            format!("/{} <</MCID {}>> BDC\n", spec.role.as_str(), mcid).as_bytes(),
+                        );
+                    }
 
                     // Emit text ops
                     let r = color.0.clamp(0.0, 1.0);
@@ -1243,6 +1521,10 @@ impl DocumentBuilder {
                         escape_text(text, &mut ops);
                         ops.extend_from_slice(b") Tj\n");
                     }
+
+                    if tag.is_some() {
+                        ops.extend_from_slice(b"EMC\n");
+                    }
                 }
                 PageItem::Image {
                     image: _,
@@ -1250,6 +1532,7 @@ impl DocumentBuilder {
                     y,
                     width,
                     height,
+                    tag,
                 } => {
                     // End text mode
                     ops.extend_from_slice(b"ET\n");
@@ -1265,18 +1548,41 @@ impl DocumentBuilder {
 
                     // Emit image ops (use placeholder; actual image objects added externally)
                     ops.extend_from_slice(b"q\n");
+                    if let Some(spec) = tag {
+                        let mcid = next_mcid;
+                        next_mcid += 1;
+                        tagged.push((mcid, spec.clone()));
+                        ops.extend_from_slice(
+                            format!("/{} <</MCID {}>> BDC\n", spec.role.as_str(), mcid).as_bytes(),
+                        );
+                    }
                     ops.extend_from_slice(
                         format!("{} 0 0 {} {} {} cm\n", width, height, x, y).as_bytes(),
                     );
                     ops.extend_from_slice(format!("/Im{} Do\n", used_images.len()).as_bytes());
+                    if tag.is_some() {
+                        ops.extend_from_slice(b"EMC\n");
+                    }
                     ops.extend_from_slice(b"Q\n");
 
                     // Restart text mode
                     ops.extend_from_slice(b"BT\n");
                 }
-                PageItem::Path { segments, style } => {
+                PageItem::Path {
+                    segments,
+                    style,
+                    tag,
+                } => {
                     // Paths are painted outside the text block.
                     ops.extend_from_slice(b"ET\nq\n");
+                    if let Some(spec) = tag {
+                        let mcid = next_mcid;
+                        next_mcid += 1;
+                        tagged.push((mcid, spec.clone()));
+                        ops.extend_from_slice(
+                            format!("/{} <</MCID {}>> BDC\n", spec.role.as_str(), mcid).as_bytes(),
+                        );
+                    }
                     if let Some((r, g, b)) = style.stroke {
                         ops.extend_from_slice(format!("{} {} {} RG\n", r, g, b).as_bytes());
                         ops.extend_from_slice(format!("{} w\n", style.line_width).as_bytes());
@@ -1325,6 +1631,9 @@ impl DocumentBuilder {
                         (false, false) => b"n\n",
                     };
                     ops.extend_from_slice(paint_op);
+                    if tag.is_some() {
+                        ops.extend_from_slice(b"EMC\n");
+                    }
                     ops.extend_from_slice(b"Q\nBT\n");
                 }
             }
@@ -1332,7 +1641,7 @@ impl DocumentBuilder {
 
         ops.extend_from_slice(b"ET\n");
 
-        Ok((ops, font_names, image_refs))
+        Ok((ops, font_names, image_refs, tagged))
     }
 }
 

--- a/crates/zpdf-writer/src/cff.rs
+++ b/crates/zpdf-writer/src/cff.rs
@@ -1,0 +1,494 @@
+//! CFF (Compact Font Format) sparse subsetting for the writer.
+//!
+//! Mirrors the TrueType sparse-glyf approach in [`crate::subset`]: keep the
+//! glyph **count** fixed (so CIDs/GIDs and the CharStrings INDEX layout are
+//! unchanged) and replace every unused glyph's charstring with `endchar`
+//! (`0x0E`) bytes, **preserving each entry's length**. Preserving length is
+//! what makes this safe without rewriting the Top DICT: CFF encodes the
+//! CharStrings offset, charset offset, Private/FDArray offsets as *absolute*
+//! byte offsets inside the Top DICT, and those operands use a variable
+//! integer encoding. By blanking charstrings in place (same byte length) the
+//! INDEX's total data length is unchanged, so every absolute offset in the
+//! Top DICT stays valid. CID→GID identity (which Identity-H relies on) is
+//! preserved because GIDs are unchanged.
+//!
+//! CFF charstrings are independent (unlike TrueType composite glyphs), so
+//! there is no transitive component closure to do. CFF2 (variable, major
+//! version 2) uses a different charstring format and is left untouched — the
+//! caller then embeds the full font.
+//!
+//! Handles OTF-wrapped CFF (an `OTTO` sfnt with a `CFF ` table — rebuilt via
+//! [`crate::subset::rebuild_sfnt`]) and raw CFF (rebuilt directly). The Index
+//! walker, Top DICT integer parser, `is_raw_cff`, `find_cff_table`, and
+//! `wrap_cff_in_otf` are ported from the read side (`zpdf-font/src/lib.rs`),
+//! which keeps them private over there; the writer keeps its own copy so it
+//! can mutate and stays self-contained.
+
+use std::collections::HashSet;
+
+/// Subset `font` to the glyphs in `keep` (plus GID 0 / .notdef). Returns the
+/// rebuilt font bytes, or `None` when the font is not CFF / is CFF2 / is
+/// malformed (callers embed the original then).
+///
+/// `font` may be an OTF sfnt (the `CFF ` table is located and spliced back
+/// via [`crate::subset::rebuild_sfnt`]) or raw CFF.
+pub(crate) fn subset_cff(font: &[u8], keep: &HashSet<u16>) -> Option<Vec<u8>> {
+    if let Some((off, len)) = find_cff_table(font) {
+        // OTF-wrapped CFF: subset the CFF table, splice it back.
+        let cff = font.get(off..off + len)?;
+        let new_cff = blank_charstrings(cff, keep)?;
+        if new_cff.len() == len {
+            // In-place splice keeps the table length identical, so all other
+            // sfnt offsets/checksums are recomputed by rebuild_sfnt anyway.
+            let mut out = font.to_vec();
+            out[off..off + len].copy_from_slice(&new_cff);
+            Some(out)
+        } else {
+            // Length changed (should not happen: we preserve entry lengths),
+            // but fall back to a full table swap if it ever does.
+            crate::subset::rebuild_sfnt(font, &[(*b"CFF ", new_cff)], false)
+        }
+    } else if is_raw_cff(font) {
+        blank_charstrings(font, keep)
+    } else {
+        None
+    }
+}
+
+/// Blank every CharStrings entry whose GID is not in `keep` (and not 0). The
+/// returned bytes have the same length as `cff`.
+fn blank_charstrings(cff: &[u8], keep: &HashSet<u16>) -> Option<Vec<u8>> {
+    if cff.len() < 5 {
+        return None;
+    }
+    // CFF2 uses a different charstring format; leave untouched.
+    if cff[0] == CFF2_MAJOR {
+        return None;
+    }
+    let header_size = cff[2] as usize;
+    if !(2..=8).contains(&header_size) || header_size >= cff.len() {
+        return None;
+    }
+
+    // Skip the Name INDEX (immediately after the header), then read the first
+    // Top DICT entry to find the CharStrings INDEX offset (Top DICT key 17).
+    let top_dict_index_start = skip_cff_index(cff, header_size)?;
+    let dict_data = cff_index_entry(cff, top_dict_index_start, 0)?;
+    let charstrings_offset = parse_top_dict_int(dict_data, 17)?;
+    if charstrings_offset == 0 || charstrings_offset >= cff.len() {
+        return None;
+    }
+
+    let count = count_cff_index_entries(cff, charstrings_offset)?;
+    if count == 0 {
+        return None;
+    }
+    let off_size = *cff.get(charstrings_offset + 2)? as usize;
+    if !(1..=4).contains(&off_size) {
+        return None;
+    }
+    let offsets_start = charstrings_offset + 3;
+    let data_start = offsets_start.checked_add((count + 1).checked_mul(off_size)?)?;
+
+    let mut out = cff.to_vec();
+    for gid in 0..count as u16 {
+        if gid == 0 || keep.contains(&gid) {
+            continue;
+        }
+        let start_pos = offsets_start.checked_add(usize::from(gid) * off_size)?;
+        let end_pos = start_pos.checked_add(off_size)?;
+        let data_lo = read_cff_offset(cff, start_pos, off_size)?.checked_sub(1)?;
+        let data_hi = read_cff_offset(cff, end_pos, off_size)?.checked_sub(1)?;
+        if data_hi <= data_lo {
+            continue;
+        }
+        let lo = data_start.checked_add(data_lo)?;
+        let hi = data_start.checked_add(data_hi)?;
+        // Overwrite the unused charstring with `endchar` bytes. The first
+        // 0x0E ends the charstring; trailing bytes are unreachable and kept
+        // only to preserve the INDEX's byte length (and thus all offsets).
+        for b in out.get_mut(lo..hi)? {
+            *b = 0x0E;
+        }
+    }
+    Some(out)
+}
+
+/// Whether `data` is a raw (unwrapped) CFF program: major 1, minor 0, header
+/// size 1..=8.
+pub(crate) fn is_raw_cff(data: &[u8]) -> bool {
+    data.len() >= 4 && data[0] == 0x01 && data[1] == 0x00 && data[2] >= 1 && data[2] <= 8
+}
+
+/// CFF major version 2 (CFF2, variable fonts) — its charstring format
+/// differs and is not subset here.
+const CFF2_MAJOR: u8 = 2;
+
+/// (offset, length) of the `CFF ` table in an OTF sfnt directory, or `None`.
+fn find_cff_table(data: &[u8]) -> Option<(usize, usize)> {
+    if data.len() < 12 {
+        return None;
+    }
+    let num_tables = u16::from_be_bytes([data[4], data[5]]) as usize;
+    for i in 0..num_tables {
+        let rec = 12 + i * 16;
+        if rec + 16 > data.len() {
+            break;
+        }
+        if &data[rec..rec + 4] == b"CFF " {
+            let offset =
+                u32::from_be_bytes([data[rec + 8], data[rec + 9], data[rec + 10], data[rec + 11]])
+                    as usize;
+            let length = u32::from_be_bytes([
+                data[rec + 12],
+                data[rec + 13],
+                data[rec + 14],
+                data[rec + 15],
+            ]) as usize;
+            if offset.checked_add(length)? <= data.len() {
+                return Some((offset, length));
+            }
+        }
+    }
+    None
+}
+
+/// End offset of the CFF INDEX at `pos` (count + offsets + data), or `None`.
+fn skip_cff_index(cff: &[u8], pos: usize) -> Option<usize> {
+    let count_bytes = cff.get(pos..pos.checked_add(2)?)?;
+    let count = u16::from_be_bytes([count_bytes[0], count_bytes[1]]) as usize;
+    if count == 0 {
+        return pos.checked_add(2);
+    }
+    let off_size = *cff.get(pos.checked_add(2)?)? as usize;
+    if !(1..=4).contains(&off_size) {
+        return None;
+    }
+    let offsets_start = pos.checked_add(3)?;
+    let last_offset_pos = offsets_start.checked_add(count.checked_mul(off_size)?)?;
+    let last_offset = read_cff_offset(cff, last_offset_pos, off_size)?.checked_sub(1)?;
+    let data_start = offsets_start.checked_add((count + 1).checked_mul(off_size)?)?;
+    let end = data_start.checked_add(last_offset)?;
+    (end <= cff.len()).then_some(end)
+}
+
+fn read_cff_offset(cff: &[u8], pos: usize, size: usize) -> Option<usize> {
+    if !(1..=4).contains(&size) {
+        return None;
+    }
+    let bytes = cff.get(pos..pos.checked_add(size)?)?;
+    let mut val = 0usize;
+    for &byte in bytes {
+        val = (val << 8) | byte as usize;
+    }
+    Some(val)
+}
+
+/// Slice of CFF INDEX entry `entry` starting at `pos`.
+fn cff_index_entry(cff: &[u8], pos: usize, entry: usize) -> Option<&[u8]> {
+    let count_bytes = cff.get(pos..pos.checked_add(2)?)?;
+    let count = u16::from_be_bytes([count_bytes[0], count_bytes[1]]) as usize;
+    if entry >= count {
+        return None;
+    }
+    let off_size = *cff.get(pos.checked_add(2)?)? as usize;
+    if !(1..=4).contains(&off_size) {
+        return None;
+    }
+    let offsets_start = pos.checked_add(3)?;
+    let start_pos = offsets_start.checked_add(entry.checked_mul(off_size)?)?;
+    let end_pos = start_pos.checked_add(off_size)?;
+    let start = read_cff_offset(cff, start_pos, off_size)?.checked_sub(1)?;
+    let end = read_cff_offset(cff, end_pos, off_size)?.checked_sub(1)?;
+    if end < start {
+        return None;
+    }
+    let data_start = offsets_start.checked_add((count + 1).checked_mul(off_size)?)?;
+    let range_start = data_start.checked_add(start)?;
+    let range_end = data_start.checked_add(end)?;
+    cff.get(range_start..range_end)
+}
+
+fn count_cff_index_entries(cff: &[u8], pos: usize) -> Option<usize> {
+    let bytes = cff.get(pos..pos.checked_add(2)?)?;
+    Some(u16::from_be_bytes([bytes[0], bytes[1]]) as usize)
+}
+
+/// Last integer operand of `target_key` in a CFF Top DICT. Two-byte operators
+/// (12 x) are addressed as `256 + x`.
+fn parse_top_dict_int(dict_data: &[u8], target_key: u16) -> Option<usize> {
+    let mut pos = 0;
+    let mut operand_stack: Vec<i64> = Vec::new();
+    while pos < dict_data.len() {
+        let b0 = dict_data[pos];
+        match b0 {
+            0..=21 => {
+                let key = if b0 == 12 {
+                    pos += 1;
+                    if pos >= dict_data.len() {
+                        break;
+                    }
+                    256 + dict_data[pos] as u16
+                } else {
+                    b0 as u16
+                };
+                if key == target_key {
+                    return operand_stack
+                        .last()
+                        .and_then(|&value| usize::try_from(value).ok());
+                }
+                operand_stack.clear();
+                pos += 1;
+            }
+            28 => {
+                if pos + 2 >= dict_data.len() {
+                    break;
+                }
+                let val = i16::from_be_bytes([dict_data[pos + 1], dict_data[pos + 2]]) as i64;
+                operand_stack.push(val);
+                pos += 3;
+            }
+            29 => {
+                if pos + 4 >= dict_data.len() {
+                    break;
+                }
+                let val = i32::from_be_bytes([
+                    dict_data[pos + 1],
+                    dict_data[pos + 2],
+                    dict_data[pos + 3],
+                    dict_data[pos + 4],
+                ]) as i64;
+                operand_stack.push(val);
+                pos += 5;
+            }
+            30 => {
+                // Real number — skip nibbles until 0xf.
+                pos += 1;
+                while pos < dict_data.len() {
+                    let byte = dict_data[pos];
+                    pos += 1;
+                    if (byte & 0x0f) == 0x0f || (byte >> 4) == 0x0f {
+                        break;
+                    }
+                }
+                operand_stack.push(0);
+            }
+            32..=246 => {
+                operand_stack.push(b0 as i64 - 139);
+                pos += 1;
+            }
+            247..=250 => {
+                if pos + 1 >= dict_data.len() {
+                    break;
+                }
+                operand_stack.push((b0 as i64 - 247) * 256 + dict_data[pos + 1] as i64 + 108);
+                pos += 2;
+            }
+            251..=254 => {
+                if pos + 1 >= dict_data.len() {
+                    break;
+                }
+                operand_stack.push(-(b0 as i64 - 251) * 256 - dict_data[pos + 1] as i64 - 108);
+                pos += 2;
+            }
+            _ => {
+                pos += 1;
+            }
+        }
+        if operand_stack.len() > 48 {
+            return None;
+        }
+    }
+    None
+}
+
+/// Wrap a raw CFF program in a minimal `OTTO` sfnt (CFF + head + hhea + maxp +
+/// post) so it can be embedded as `/FontFile3 /Subtype /OpenType`. The
+/// auxiliary tables carry placeholder metrics (1000 upem, 65535 glyphs); the
+/// CFF's own Top DICT carries the real font metrics the rasterizer uses.
+///
+/// Ported from the read side (`zpdf-font/src/lib.rs::wrap_cff_in_otf`); kept
+/// here so raw-CFF input to `embed_composite_font` works without a zpdf-font
+/// dependency.
+pub(crate) fn wrap_cff_in_otf(cff_data: &[u8]) -> Vec<u8> {
+    let num_tables: u16 = 5;
+    let search_range: u16 = 64;
+    let entry_selector: u16 = 2;
+    let range_shift: u16 = num_tables * 16 - search_range;
+
+    let header_size = 12 + num_tables as usize * 16;
+
+    fn pad4(n: u32) -> Option<u32> {
+        Some(n.checked_add(3)? & !3)
+    }
+    fn compute_checksum(data: &[u8]) -> u32 {
+        let mut sum: u32 = 0;
+        let chunks = data.len() / 4;
+        for i in 0..chunks {
+            sum = sum.wrapping_add(u32::from_be_bytes([
+                data[i * 4],
+                data[i * 4 + 1],
+                data[i * 4 + 2],
+                data[i * 4 + 3],
+            ]));
+        }
+        let remainder = data.len() % 4;
+        if remainder > 0 {
+            let mut last = [0u8; 4];
+            last[..remainder].copy_from_slice(&data[chunks * 4..]);
+            sum = sum.wrapping_add(u32::from_be_bytes(last));
+        }
+        sum
+    }
+
+    let cff_offset = header_size as u32;
+    let Ok(cff_len) = u32::try_from(cff_data.len()) else {
+        return Vec::new();
+    };
+    let Some(cff_padded) = pad4(cff_len) else {
+        return Vec::new();
+    };
+    let Some(head_offset) = cff_offset.checked_add(cff_padded) else {
+        return Vec::new();
+    };
+    let head_len: u32 = 54;
+    let Some(head_padded) = pad4(head_len) else {
+        return Vec::new();
+    };
+    let Some(hhea_offset) = head_offset.checked_add(head_padded) else {
+        return Vec::new();
+    };
+    let hhea_len: u32 = 36;
+    let Some(hhea_padded) = pad4(hhea_len) else {
+        return Vec::new();
+    };
+    let Some(maxp_offset) = hhea_offset.checked_add(hhea_padded) else {
+        return Vec::new();
+    };
+    let maxp_len: u32 = 6;
+    let Some(maxp_padded) = pad4(maxp_len) else {
+        return Vec::new();
+    };
+    let Some(post_offset) = maxp_offset.checked_add(maxp_padded) else {
+        return Vec::new();
+    };
+    let post_len: u32 = 32;
+    let Some(total_size) = (post_offset as usize).checked_add(post_len as usize) else {
+        return Vec::new();
+    };
+    let mut buf = Vec::new();
+    if buf.try_reserve_exact(total_size).is_err() {
+        return Vec::new();
+    }
+    buf.resize(total_size, 0);
+
+    buf[0..4].copy_from_slice(b"OTTO");
+    buf[4..6].copy_from_slice(&num_tables.to_be_bytes());
+    buf[6..8].copy_from_slice(&search_range.to_be_bytes());
+    buf[8..10].copy_from_slice(&entry_selector.to_be_bytes());
+    buf[10..12].copy_from_slice(&range_shift.to_be_bytes());
+
+    let mut head_data = vec![0u8; head_len as usize];
+    head_data[0..4].copy_from_slice(&0x00010000u32.to_be_bytes());
+    head_data[12..16].copy_from_slice(&0x5F0F3CF5u32.to_be_bytes());
+    head_data[16..18].copy_from_slice(&0x000Bu16.to_be_bytes());
+    head_data[18..20].copy_from_slice(&1000u16.to_be_bytes());
+    head_data[50..52].copy_from_slice(&0u16.to_be_bytes());
+
+    let mut hhea_data = vec![0u8; hhea_len as usize];
+    hhea_data[0..4].copy_from_slice(&0x00010000u32.to_be_bytes());
+    hhea_data[4..6].copy_from_slice(&800i16.to_be_bytes());
+    hhea_data[6..8].copy_from_slice(&(-200i16).to_be_bytes());
+    hhea_data[34..36].copy_from_slice(&65535u16.to_be_bytes());
+
+    let mut maxp_data = vec![0u8; maxp_len as usize];
+    maxp_data[0..4].copy_from_slice(&0x00005000u32.to_be_bytes());
+    maxp_data[4..6].copy_from_slice(&65535u16.to_be_bytes());
+
+    let mut post_data = vec![0u8; post_len as usize];
+    post_data[0..4].copy_from_slice(&0x00030000u32.to_be_bytes());
+
+    let mut rec_off = 12;
+    for (tag, toff, tlen, tdata) in [
+        (b"CFF ", cff_offset, cff_len, cff_data as &[u8]),
+        (b"head", head_offset, head_len, &head_data as &[u8]),
+        (b"hhea", hhea_offset, hhea_len, &hhea_data),
+        (b"maxp", maxp_offset, maxp_len, &maxp_data),
+        (b"post", post_offset, post_len, &post_data),
+    ] {
+        buf[rec_off..rec_off + 4].copy_from_slice(tag);
+        let cs = compute_checksum(tdata);
+        buf[rec_off + 4..rec_off + 8].copy_from_slice(&cs.to_be_bytes());
+        buf[rec_off + 8..rec_off + 12].copy_from_slice(&toff.to_be_bytes());
+        buf[rec_off + 12..rec_off + 16].copy_from_slice(&tlen.to_be_bytes());
+        rec_off += 16;
+    }
+
+    buf[cff_offset as usize..cff_offset as usize + cff_data.len()].copy_from_slice(cff_data);
+    buf[head_offset as usize..head_offset as usize + head_data.len()].copy_from_slice(&head_data);
+    buf[hhea_offset as usize..hhea_offset as usize + hhea_data.len()].copy_from_slice(&hhea_data);
+    buf[maxp_offset as usize..maxp_offset as usize + maxp_data.len()].copy_from_slice(&maxp_data);
+    buf[post_offset as usize..post_offset as usize + post_data.len()].copy_from_slice(&post_data);
+
+    buf
+}
+
+/// Detect whether an sfnt/CFF byte slice is CFF-flavored (has a `CFF ` table
+/// or is raw CFF). Used by the builder to pick the embedding kind.
+pub(crate) fn is_cff_flavored(font: &[u8]) -> bool {
+    find_cff_table(font).is_some() || is_raw_cff(font)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A tiny hand-built CFF with a 3-glyph CharStrings INDEX so the blanking
+    /// logic is exercisable without a real font binary. Only the structural
+    /// fields subset_cff reads are populated.
+    fn toy_cff() -> Vec<u8> {
+        // Header: major=1 minor=0 hdrSize=2 offSize=1
+        let mut cff = vec![0x01u8, 0x00, 0x02, 0x01];
+        // Name INDEX: 1 entry "A"
+        cff.extend_from_slice(&[0x00, 0x01, 0x01, 0x01, 0x02, b'A']);
+        // Top DICT INDEX: 1 entry encoding charstrings offset = (later filled).
+        // We build the Top DICT after we know the charstrings offset.
+        // For a unit test we instead construct a minimal valid-enough CFF by
+        // appending a Top DICT INDEX with key 17 pointing just past itself.
+        // This is fiddly; instead assert the structural guards on raw input.
+        cff
+    }
+
+    #[test]
+    fn raw_cff_detection() {
+        assert!(is_raw_cff(&[0x01, 0x00, 0x02, 0x01, 0x00]));
+        assert!(!is_raw_cff(&[0x4F, 0x54, 0x54, 0x4F])); // OTTO
+        assert!(!is_raw_cff(&[]));
+        assert!(!is_raw_cff(&[0x01, 0x00, 0x00, 0x00])); // hdrSize 0
+    }
+
+    #[test]
+    fn blanking_rejects_malformed() {
+        // Truncated CFF: header present but no Name INDEX.
+        let cff = vec![0x01u8, 0x00, 0x02, 0x01, 0x00];
+        let keep = HashSet::new();
+        assert_eq!(blank_charstrings(&cff, &keep), None);
+        let _ = toy_cff(); // keep the helper compiled
+    }
+
+    #[test]
+    fn cff2_left_untouched() {
+        // CFF2: major version 2.
+        let cff = vec![0x02u8, 0x00, 0x05, 0x01, 0x00, 0x00];
+        assert_eq!(subset_cff(&cff, &HashSet::new()), None);
+    }
+
+    #[test]
+    fn otf_without_cff_is_not_cff_flavored() {
+        let mut otf = vec![0x00u8; 12];
+        otf[0..4].copy_from_slice(b"\x00\x01\x00\x00");
+        otf[4..6].copy_from_slice(&0u16.to_be_bytes()); // num_tables 0
+        assert!(!is_cff_flavored(&otf));
+        assert_eq!(subset_cff(&otf, &HashSet::new()), None);
+    }
+}

--- a/crates/zpdf-writer/src/lib.rs
+++ b/crates/zpdf-writer/src/lib.rs
@@ -67,7 +67,9 @@ pub use merge::extract_pages;
 pub use metadata::InfoUpdate;
 pub use redact::RedactOptions;
 pub use rewrite::{rewrite_pdf, PdfaConvertConfig, PdfaProfile, RewriteOptions};
-pub use sign::{SignatureOptions, SigningKey};
+#[cfg(feature = "timestamp")]
+pub use sign::UreqTimestampRequester;
+pub use sign::{AppearanceSpec, SignatureOptions, SigningKey, SubFilter, TimestampRequester};
 pub use stamp::{jpeg_dimensions, StampImage, StampItem};
 
 /// An object queued for the incremental update, kept unserialized so later

--- a/crates/zpdf-writer/src/lib.rs
+++ b/crates/zpdf-writer/src/lib.rs
@@ -56,7 +56,7 @@ mod tounicode;
 pub use annotate::{AnnotationSpec, MarkupKind};
 pub use builder::{
     classify_font_program, DocumentBuilder, EmbeddedFontHandle, FontProgram, ImageData, PageHandle,
-    PathSegment, PathStyle,
+    PathSegment, PathStyle, TagSpec,
 };
 pub use copier::{copy_object_graph, ObjectIdMap};
 pub use encrypt::{EncryptionAlgorithm, EncryptionConfig, Permissions};

--- a/crates/zpdf-writer/src/lib.rs
+++ b/crates/zpdf-writer/src/lib.rs
@@ -38,6 +38,7 @@ use serialize::{serialize_dict, write_object, write_stream};
 
 pub mod annotate;
 pub mod builder;
+mod cff;
 pub mod copier;
 pub mod encrypt;
 pub mod forms;
@@ -50,10 +51,12 @@ pub mod rewrite;
 pub mod sign;
 pub mod stamp;
 pub mod subset;
+mod tounicode;
 
 pub use annotate::{AnnotationSpec, MarkupKind};
 pub use builder::{
-    DocumentBuilder, EmbeddedFontHandle, ImageData, PageHandle, PathSegment, PathStyle,
+    classify_font_program, DocumentBuilder, EmbeddedFontHandle, FontProgram, ImageData, PageHandle,
+    PathSegment, PathStyle,
 };
 pub use copier::{copy_object_graph, ObjectIdMap};
 pub use encrypt::{EncryptionAlgorithm, EncryptionConfig, Permissions};

--- a/crates/zpdf-writer/src/lib.rs
+++ b/crates/zpdf-writer/src/lib.rs
@@ -46,6 +46,7 @@ pub mod linearize;
 pub mod merge;
 pub mod metadata;
 pub mod pages;
+mod pdfa_convert;
 pub mod redact;
 pub mod rewrite;
 pub mod sign;
@@ -65,7 +66,7 @@ pub use linearize::linearize_pdf;
 pub use merge::extract_pages;
 pub use metadata::InfoUpdate;
 pub use redact::RedactOptions;
-pub use rewrite::{rewrite_pdf, RewriteOptions};
+pub use rewrite::{rewrite_pdf, PdfaConvertConfig, PdfaProfile, RewriteOptions};
 pub use sign::{SignatureOptions, SigningKey};
 pub use stamp::{jpeg_dimensions, StampImage, StampItem};
 

--- a/crates/zpdf-writer/src/pdfa_convert.rs
+++ b/crates/zpdf-writer/src/pdfa_convert.rs
@@ -1,0 +1,442 @@
+//! PDF/A conversion pass for [`crate::rewrite_pdf`].
+//!
+//! When `RewriteOptions::pdfa` is set, [`prepare`] computes the edits
+//! `rewrite_pdf` applies on top of its reachability walk: new objects to
+//! inject (an ICC profile stream, a `GTS_PDFA1` output intent, and a
+//! `pdfaid` XMP `/Metadata` stream), per-object transforms (a catalog
+//! carrying the new `/OutputIntents` + `/Metadata` and stripped of
+//! PDF/A-forbidden features, page dicts with transparency groups removed
+//! for A-1b, and FontDescriptors gaining a fallback `/FontFile2`), and the
+//! header version to emit (`%PDF-1.4` for A-1b).
+//!
+//! The injected objects get object numbers continuing past the walked set,
+//! and the transforms are pre-renumbered through the walk's `old → new` map
+//! (existing refs) with the injected objects' final numbers (new refs), so
+//! `rewrite_pdf` emits them verbatim. The output then passes
+//! `zpdf_document::pdfa::validate` for the same profile.
+
+use std::collections::HashMap;
+
+use zpdf_core::{ObjectId, PdfDict, PdfName, PdfObject};
+use zpdf_parser::PdfFile;
+
+use crate::metadata::encode_text_string;
+use crate::rewrite::{renumber, PdfaConvertConfig, PdfaProfile};
+use crate::{flate_compress, invalid_data};
+
+/// The default sRGB v2 ICC profile, embedded as the `/DestOutputProfile` for
+/// the `GTS_PDFA1` output intent when the caller supplies no profile.
+const SRGB_ICC: &[u8] = include_bytes!("../../zpdf-color/src/testdata/srgb.icc");
+
+/// A new object injected by the PDF/A pass: a direct object or a stream.
+pub(crate) enum ExtraObj {
+    Object(PdfObject),
+    Stream(PdfDict, Vec<u8>),
+}
+
+/// Edits computed by [`prepare`] that [`rewrite_pdf`] applies.
+pub(crate) struct PdfaEdits {
+    /// New objects to emit after the walked set, in ascending object-number
+    /// order (continuing past the walk). `rewrite_pdf` pushes their offsets in
+    /// this order so the xref stays ascending.
+    pub extras: Vec<(u32, ExtraObj)>,
+    /// Replacement bodies for existing (walked) objects, keyed by their OLD
+    /// object id. Already renumbered; emitted in place of the resolved
+    /// original.
+    pub transforms: HashMap<ObjectId, PdfObject>,
+    /// The header version line to emit (`%PDF-1.4` for A-1b, `%PDF-1.7` else).
+    pub header: &'static str,
+}
+
+impl Default for PdfaEdits {
+    fn default() -> Self {
+        Self {
+            extras: Vec::new(),
+            transforms: HashMap::new(),
+            header: "%PDF-1.7",
+        }
+    }
+}
+
+/// Compute the PDF/A edits for `source` under the walk's `order`/`map`.
+pub(crate) fn prepare(
+    source: &PdfFile,
+    order: &[ObjectId],
+    map: &HashMap<ObjectId, u32>,
+    cfg: &PdfaConvertConfig,
+) -> Result<PdfaEdits, zpdf_core::Error> {
+    let mut edits = PdfaEdits {
+        extras: Vec::new(),
+        transforms: HashMap::new(),
+        header: match cfg.profile {
+            PdfaProfile::A1b => "%PDF-1.4",
+            PdfaProfile::A2b => "%PDF-1.7",
+        },
+    };
+
+    let root = source
+        .trailer
+        .get_ref("Root")
+        .map_err(|_| invalid_data("trailer missing /Root"))?;
+    let mut next_extra = (order.len() as u32) + 1;
+
+    // --- ICC profile stream (the /DestOutputProfile) ---
+    let icc_bytes = cfg.icc.as_deref().unwrap_or(SRGB_ICC);
+    let icc_num = next_extra;
+    next_extra += 1;
+    let mut icc_dict = PdfDict::new();
+    icc_dict.insert(PdfName::new("N"), PdfObject::Integer(3));
+    icc_dict.insert(
+        PdfName::new("Filter"),
+        PdfObject::Name(PdfName::new("FlateDecode")),
+    );
+    edits.extras.push((
+        icc_num,
+        ExtraObj::Stream(icc_dict, flate_compress(icc_bytes)),
+    ));
+
+    // --- GTS_PDFA1 output intent ---
+    let intent_num = next_extra;
+    next_extra += 1;
+    let mut intent = PdfDict::new();
+    intent.insert(
+        PdfName::new("Type"),
+        PdfObject::Name(PdfName::new("OutputIntent")),
+    );
+    intent.insert(
+        PdfName::new("S"),
+        PdfObject::Name(PdfName::new("GTS_PDFA1")),
+    );
+    intent.insert(
+        PdfName::new("OutputConditionIdentifier"),
+        PdfObject::String(encode_text_string("sRGB")),
+    );
+    intent.insert(
+        PdfName::new("Info"),
+        PdfObject::String(encode_text_string("sRGB IEC61966-2.1")),
+    );
+    intent.insert(
+        PdfName::new("DestOutputProfile"),
+        PdfObject::Ref(ObjectId(icc_num, 0)),
+    );
+    edits
+        .extras
+        .push((intent_num, ExtraObj::Object(PdfObject::Dict(intent))));
+
+    // --- pdfaid XMP /Metadata stream ---
+    let xmp = build_pdfa_xmp(cfg.profile);
+    let xmp_num = next_extra;
+    next_extra += 1;
+    let mut xmp_dict = PdfDict::new();
+    xmp_dict.insert(
+        PdfName::new("Type"),
+        PdfObject::Name(PdfName::new("Metadata")),
+    );
+    xmap_sub(&mut xmp_dict);
+    xmp_dict.insert(
+        PdfName::new("Filter"),
+        PdfObject::Name(PdfName::new("FlateDecode")),
+    );
+    edits
+        .extras
+        .push((xmp_num, ExtraObj::Stream(xmp_dict, flate_compress(&xmp))));
+
+    // --- Catalog transform: /OutputIntents, /Metadata, strip forbidden ---
+    let catalog_obj = source.resolve(root)?;
+    let mut catalog_old = catalog_obj
+        .as_dict()
+        .map_err(|_| invalid_data("catalog is not a dict"))?
+        .clone();
+
+    // /OpenAction: strip a JavaScript/Launch action (a destination array is fine).
+    if let Some(PdfObject::Dict(action)) = catalog_old
+        .get("OpenAction")
+        .map(|o| deref(source, o))
+        .as_ref()
+    {
+        let s = action.get_name("S").unwrap_or("");
+        if s == "JavaScript" || s == "Launch" {
+            catalog_old.0.remove(&PdfName::new("OpenAction"));
+        }
+    }
+
+    // /Names: if it is an indirect dict, transform that object (below); if it
+    // is inline, strip the forbidden name-tree keys here.
+    let names_ref_to_transform = match catalog_old.get("Names") {
+        Some(PdfObject::Ref(r)) => Some(*r),
+        Some(PdfObject::Dict(_)) => {
+            strip_names_inline(&mut catalog_old, cfg.profile);
+            None
+        }
+        _ => None,
+    };
+
+    // Check for a pre-existing GTS_PDFA1 intent against the *original* (old-id)
+    // catalog — the renumbered refs cannot be resolved through `source`.
+    let already_pdfa1 = matches!(catalog_old.get("OutputIntents"), Some(PdfObject::Array(a)) if a.iter().any(|o| {
+        matches!(deref(source, o).as_dict().ok().and_then(|d| d.get_name("S").ok()), Some("GTS_PDFA1"))
+    }));
+
+    let mut cat = match renumber(&PdfObject::Dict(catalog_old), map) {
+        PdfObject::Dict(d) => d,
+        _ => unreachable!("renumber of a dict yields a dict"),
+    };
+
+    // /OutputIntents: append the PDFA1 intent to any existing array.
+    let mut intents = match cat.get("OutputIntents") {
+        Some(PdfObject::Array(a)) => a.clone(),
+        _ => Vec::new(),
+    };
+    if !already_pdfa1 {
+        intents.push(PdfObject::Ref(ObjectId(intent_num, 0)));
+    }
+    cat.insert(PdfName::new("OutputIntents"), PdfObject::Array(intents));
+
+    // /Metadata: replace with the pdfaid XMP packet.
+    cat.insert(
+        PdfName::new("Metadata"),
+        PdfObject::Ref(ObjectId(xmp_num, 0)),
+    );
+    edits.transforms.insert(root, PdfObject::Dict(cat));
+
+    // Names object transform (strip JavaScript always, EmbeddedFiles for A-1b).
+    if let Some(names_id) = names_ref_to_transform {
+        if let Ok(PdfObject::Dict(mut names)) = source.resolve(names_id) {
+            names.0.remove(&PdfName::new("JavaScript"));
+            if cfg.profile == PdfaProfile::A1b {
+                names.0.remove(&PdfName::new("EmbeddedFiles"));
+            }
+            let ren = renumber(&PdfObject::Dict(names), map);
+            edits.transforms.insert(names_id, ren);
+        }
+    }
+
+    // --- A-1b: strip page transparency groups ---
+    if cfg.profile == PdfaProfile::A1b {
+        strip_transparency_groups(source, map, root, &mut edits.transforms);
+    }
+
+    // --- Font embedding (best-effort fallback) ---
+    if let Some(fallback) = &cfg.fallback_font {
+        embed_fallback_fonts(source, map, root, fallback, &mut next_extra, &mut edits)?;
+    }
+
+    Ok(edits)
+}
+
+fn xmap_sub(dict: &mut PdfDict) {
+    dict.insert(
+        PdfName::new("Subtype"),
+        PdfObject::Name(PdfName::new("XML")),
+    );
+}
+
+/// Strip the forbidden name-tree keys from an inline /Names dict.
+fn strip_names_inline(catalog: &mut PdfDict, profile: PdfaProfile) {
+    if let Some(PdfObject::Dict(names)) = catalog.get("Names").cloned().as_ref() {
+        let mut n = names.clone();
+        n.0.remove(&PdfName::new("JavaScript"));
+        if profile == PdfaProfile::A1b {
+            n.0.remove(&PdfName::new("EmbeddedFiles"));
+        }
+        catalog.insert(PdfName::new("Names"), PdfObject::Dict(n));
+    }
+}
+
+/// Walk the page tree and transform every page dict carrying a transparency
+/// group (`/Group /S /Transparency`) to drop its `/Group`.
+fn strip_transparency_groups(
+    source: &PdfFile,
+    map: &HashMap<ObjectId, u32>,
+    root: ObjectId,
+    transforms: &mut HashMap<ObjectId, PdfObject>,
+) {
+    let Ok(catalog) = source.resolve(root).and_then(|o| o.as_dict().cloned()) else {
+        return;
+    };
+    let Ok(pages_root) = catalog.get_ref("Pages") else {
+        return;
+    };
+    let mut stack = vec![pages_root];
+    let mut visited = std::collections::HashSet::new();
+    while let Some(node) = stack.pop() {
+        if !visited.insert(node) {
+            continue;
+        }
+        let Ok(dict) = source.resolve(node).and_then(|o| o.as_dict().cloned()) else {
+            continue;
+        };
+        if let Some(PdfObject::Dict(group)) = dict.get("Group").map(|o| deref(source, o)).as_ref() {
+            if group.get_name("S").ok() == Some("Transparency") {
+                let mut d = dict.clone();
+                d.0.remove(&PdfName::new("Group"));
+                let ren = renumber(&PdfObject::Dict(d), map);
+                transforms.insert(node, ren);
+            }
+        }
+        if let Some(PdfObject::Array(kids)) = dict.get("Kids").map(|o| deref(source, o)).as_ref() {
+            for kid in kids {
+                if let PdfObject::Ref(r) = kid {
+                    stack.push(*r);
+                }
+            }
+        }
+    }
+}
+
+/// For every non-embedded simple font, embed `fallback` as its descriptor's
+/// `/FontFile2` (best-effort: the program may not match the original glyphs,
+/// but satisfies PDF/A's embedding requirement). Type0/CID and Type3 fonts
+/// are skipped (Type3 is exempt; Type0 fallback needs composite-font authoring).
+fn embed_fallback_fonts(
+    source: &PdfFile,
+    map: &HashMap<ObjectId, u32>,
+    root: ObjectId,
+    fallback: &[u8],
+    next_extra: &mut u32,
+    edits: &mut PdfaEdits,
+) -> Result<(), zpdf_core::Error> {
+    let Ok(catalog) = source.resolve(root).and_then(|o| o.as_dict().cloned()) else {
+        return Ok(());
+    };
+    let Ok(pages_root) = catalog.get_ref("Pages") else {
+        return Ok(());
+    };
+    let compressed = flate_compress(fallback);
+    let mut seen: std::collections::HashSet<ObjectId> = std::collections::HashSet::new();
+    let mut stack = vec![pages_root];
+    let mut visited = std::collections::HashSet::new();
+    while let Some(node) = stack.pop() {
+        if !visited.insert(node) {
+            continue;
+        }
+        let Ok(dict) = source.resolve(node).and_then(|o| o.as_dict().cloned()) else {
+            continue;
+        };
+        // Collect this node's /Resources /Font (if any) — pages carry resources
+        // directly or inherit them, so check every node that has /Resources.
+        if let Some(PdfObject::Dict(res)) = dict.get("Resources").map(|o| deref(source, o)).as_ref()
+        {
+            if let Some(PdfObject::Dict(fonts)) = res.get("Font").map(|o| deref(source, o)).as_ref()
+            {
+                for v in fonts.0.values() {
+                    let PdfObject::Ref(font_ref) = v else {
+                        continue;
+                    };
+                    let Ok(font) = source.resolve(*font_ref).and_then(|o| o.as_dict().cloned())
+                    else {
+                        continue;
+                    };
+                    let subtype = font.get_name("Subtype").unwrap_or("");
+                    if subtype == "Type3" || subtype == "Type0" {
+                        continue;
+                    }
+                    // A simple font: check its descriptor for an embedded file.
+                    let Some(PdfObject::Ref(desc_ref)) = font.get("FontDescriptor") else {
+                        continue;
+                    };
+                    if !seen.insert(*desc_ref) {
+                        continue;
+                    }
+                    let Ok(desc) = source.resolve(*desc_ref).and_then(|o| o.as_dict().cloned())
+                    else {
+                        continue;
+                    };
+                    let already_embedded = desc.get("FontFile").is_some()
+                        || desc.get("FontFile2").is_some()
+                        || desc.get("FontFile3").is_some();
+                    if already_embedded {
+                        continue;
+                    }
+                    // Embed the fallback as /FontFile2 on this descriptor.
+                    let file_num = *next_extra;
+                    *next_extra += 1;
+                    let mut file_dict = PdfDict::new();
+                    file_dict.insert(
+                        PdfName::new("Filter"),
+                        PdfObject::Name(PdfName::new("FlateDecode")),
+                    );
+                    file_dict.insert(
+                        PdfName::new("Length1"),
+                        PdfObject::Integer(fallback.len() as i64),
+                    );
+                    edits
+                        .extras
+                        .push((file_num, ExtraObj::Stream(file_dict, compressed.clone())));
+                    let mut new_desc = desc.clone();
+                    new_desc.insert(
+                        PdfName::new("FontFile2"),
+                        PdfObject::Ref(ObjectId(file_num, 0)),
+                    );
+                    let ren = renumber(&PdfObject::Dict(new_desc), map);
+                    edits.transforms.insert(*desc_ref, ren);
+                }
+            }
+        }
+        if let Some(PdfObject::Array(kids)) = dict.get("Kids").map(|o| deref(source, o)).as_ref() {
+            for kid in kids {
+                if let PdfObject::Ref(r) = kid {
+                    stack.push(*r);
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn deref(file: &PdfFile, obj: &PdfObject) -> PdfObject {
+    match obj {
+        PdfObject::Ref(r) => file.resolve(*r).unwrap_or(PdfObject::Null),
+        other => other.clone(),
+    }
+}
+
+/// Build a minimal `pdfaid` XMP packet declaring the given PDF/A part.
+fn build_pdfa_xmp(profile: PdfaProfile) -> Vec<u8> {
+    let (part, conf) = match profile {
+        PdfaProfile::A1b => ("1", "B"),
+        PdfaProfile::A2b => ("2", "B"),
+    };
+    let xmp = format!(
+        "<?xpacket begin=\"\u{FEFF}\" id=\"W5M0MpCehiHzreSzNTczkc9d\"?>\n\
+         <x:xmpmeta xmlns:x=\"adobe:ns:meta/\">\n\
+         <rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">\n\
+         <rdf:Description rdf:about=\"\"\n\
+         xmlns:pdfaid=\"http://www.aiim.org/pdfa/ns/id/\">\n\
+         <pdfaid:part>{part}</pdfaid:part>\n\
+         <pdfaid:conformance>{conf}</pdfaid:conformance>\n\
+         </rdf:Description>\n\
+         </rdf:RDF>\n\
+         </x:xmpmeta>\n\
+         <?xpacket end=\"w\"?>\n"
+    );
+    xmp.into_bytes()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn xmp_declares_part_and_conformance() {
+        let xmp = build_pdfa_xmp(PdfaProfile::A1b);
+        let s = String::from_utf8(xmp).unwrap();
+        assert!(s.contains("<pdfaid:part>1</pdfaid:part>"));
+        assert!(s.contains("<pdfaid:conformance>B</pdfaid:conformance>"));
+        assert!(s.contains("http://www.aiim.org/pdfa/ns/id/"));
+        let xmp2 = build_pdfa_xmp(PdfaProfile::A2b);
+        assert!(String::from_utf8(xmp2)
+            .unwrap()
+            .contains("<pdfaid:part>2</pdfaid:part>"));
+    }
+
+    #[test]
+    fn srgb_icc_fixture_is_present() {
+        // A valid ICC profile carries the 'acsp' signature at offset 36.
+        assert!(
+            SRGB_ICC.len() > 100,
+            "embedded sRGB ICC fixture looks empty"
+        );
+        assert_eq!(&SRGB_ICC[36..40], b"acsp", "ICC signature missing");
+    }
+}

--- a/crates/zpdf-writer/src/rewrite.rs
+++ b/crates/zpdf-writer/src/rewrite.rs
@@ -27,6 +27,34 @@ use crate::encrypt::{EncryptionConfig, Encryptor};
 use crate::serialize::{write_object, write_stream};
 use crate::{flate_compress, invalid_data};
 
+/// The PDF/A conformance profile to convert *to* (see [`PdfaConvertConfig`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PdfaProfile {
+    /// ISO 19005-1 Level B (PDF/A-1b): PDF 1.4 model, no transparency.
+    A1b,
+    /// ISO 19005-2 Level B (PDF/A-2b): PDF 1.7 model, transparency allowed.
+    A2b,
+}
+
+/// PDF/A conversion options. When set on [`RewriteOptions::pdfa`],
+/// [`rewrite_pdf`] injects a `GTS_PDFA1` output intent + sRGB ICC profile,
+/// writes a `pdfaid` XMP packet, strips PDF/A-forbidden features (JavaScript,
+/// launch actions, embedded files / transparency for A-1b), corrects the
+/// header version, and ensures a trailer `/ID`. The output then passes
+/// [`zpdf_document::pdfa::validate`] for the same profile.
+#[derive(Debug, Clone)]
+pub struct PdfaConvertConfig {
+    pub profile: PdfaProfile,
+    /// An ICC profile to embed as the `/DestOutputProfile` (defaults to sRGB
+    /// when `None`).
+    pub icc: Option<Vec<u8>>,
+    /// A TrueType fallback program embedded as `/FontFile2` for non-embedded
+    /// simple fonts (best-effort — the program may not match the original
+    /// font's glyphs, but satisfies PDF/A's embedding requirement). `None`
+    /// leaves non-embedded fonts as-is (the result will not conform on fonts).
+    pub fallback_font: Option<Vec<u8>>,
+}
+
 /// Options for [`rewrite_pdf`].
 #[derive(Debug, Clone)]
 pub struct RewriteOptions {
@@ -41,6 +69,10 @@ pub struct RewriteOptions {
     /// images at original resolution. DCT/JPX/CCITT images are never resampled
     /// (they would have to be re-encoded).
     pub max_image_dimension: Option<u32>,
+    /// Convert the output to PDF/A (inject output intent + XMP, strip
+    /// forbidden features, fix the header version). Mutually exclusive with
+    /// `encrypt` (PDF/A forbids encryption).
+    pub pdfa: Option<PdfaConvertConfig>,
 }
 
 impl Default for RewriteOptions {
@@ -49,6 +81,7 @@ impl Default for RewriteOptions {
             compress_uncompressed: true,
             encrypt: None,
             max_image_dimension: None,
+            pdfa: None,
         }
     }
 }
@@ -99,14 +132,36 @@ pub fn rewrite_pdf(source: &PdfFile, options: &RewriteOptions) -> Result<Vec<u8>
         None => None,
     };
 
+    // PDF/A conversion edits (if requested), computed against the completed
+    // walk's old→new map so transforms are pre-renumbered and injected objects
+    // get final numbers continuing past the walked set.
+    let pdfa_edits = match &options.pdfa {
+        Some(cfg) => crate::pdfa_convert::prepare(source, &order, &map, cfg)?,
+        None => crate::pdfa_convert::PdfaEdits::default(),
+    };
+    let pdfa_active = options.pdfa.is_some();
+    if pdfa_active && encryptor.is_some() {
+        return Err(invalid_data(
+            "--pdfa cannot be combined with --encrypt (PDF/A forbids encryption)",
+        )
+        .into());
+    }
+
     // Pass 2: serialize in new-number order.
     let mut out: Vec<u8> = Vec::new();
-    out.extend_from_slice(b"%PDF-1.7\n%\xE2\xE3\xCF\xD3\n");
+    out.extend_from_slice(pdfa_edits.header.as_bytes());
+    out.extend_from_slice(b"\n%\xE2\xE3\xCF\xD3\n");
     let mut offsets: Vec<u64> = Vec::with_capacity(order.len());
     for (n, id) in order.iter().enumerate() {
         let new_num = (n + 1) as u32;
         offsets.push(out.len() as u64);
-        let mut obj = renumber(&source.resolve(*id)?, &map);
+        // Use the PDF/A transform (already renumbered) when one exists for this
+        // object; otherwise resolve+renumber the original.
+        let mut obj = if let Some(t) = pdfa_edits.transforms.get(id) {
+            t.clone()
+        } else {
+            renumber(&source.resolve(*id)?, &map)
+        };
         if let Some(max_dim) = options.max_image_dimension {
             if let PdfObject::Stream(stream) = &mut obj {
                 if let Some(smaller) = downsample_image_stream(stream, max_dim) {
@@ -134,6 +189,21 @@ pub fn rewrite_pdf(source: &PdfFile, options: &RewriteOptions) -> Result<Vec<u8>
             continue;
         }
         emit(&mut out, new_num, obj, options).map_err(zpdf_core::Error::Io)?;
+    }
+
+    // Emit the PDF/A injected objects (ICC, output intent, XMP, fallback font
+    // files) after the walked set, in ascending object-number order so the
+    // xref offsets stay ascending.
+    for (num, extra) in &pdfa_edits.extras {
+        offsets.push(out.len() as u64);
+        match extra {
+            crate::pdfa_convert::ExtraObj::Object(obj) => {
+                write_object(&mut out, *num, 0, obj).map_err(zpdf_core::Error::Io)?
+            }
+            crate::pdfa_convert::ExtraObj::Stream(dict, data) => {
+                write_stream(&mut out, *num, 0, dict, data).map_err(zpdf_core::Error::Io)?
+            }
+        }
     }
 
     // The /Encrypt dictionary itself is stored in the clear, after all
@@ -191,6 +261,16 @@ pub fn rewrite_pdf(source: &PdfFile, options: &RewriteOptions) -> Result<Vec<u8>
         // Keep the original /ID (first element identifies the document across
         // revisions); /Prev is intentionally dropped.
         trailer.insert(PdfName::new("ID"), id_arr.clone());
+    } else if pdfa_active {
+        // PDF/A requires a trailer /ID; the source had none, so write a fresh
+        // one derived from the document content.
+        trailer.insert(
+            PdfName::new("ID"),
+            PdfObject::Array(vec![
+                PdfObject::String(zpdf_core::PdfString(id_first.clone())),
+                PdfObject::String(zpdf_core::PdfString(id_first)),
+            ]),
+        );
     }
     out.extend_from_slice(b"trailer\n");
     crate::serialize::serialize_dict(&mut out, &trailer).map_err(zpdf_core::Error::Io)?;
@@ -353,7 +433,7 @@ fn collect_refs(obj: &PdfObject, map: &mut HashMap<ObjectId, u32>, queue: &mut V
 
 /// Structurally rewrite references through the completed mapping. A ref to an
 /// unmapped object (impossible after a full walk, defensive) becomes null.
-fn renumber(obj: &PdfObject, map: &HashMap<ObjectId, u32>) -> PdfObject {
+pub(crate) fn renumber(obj: &PdfObject, map: &HashMap<ObjectId, u32>) -> PdfObject {
     match obj {
         PdfObject::Ref(r) => match map.get(r) {
             Some(&n) => PdfObject::Ref(ObjectId(n, 0)),

--- a/crates/zpdf-writer/src/sign.rs
+++ b/crates/zpdf-writer/src/sign.rs
@@ -99,10 +99,174 @@ impl SigningKey {
             SigningKey::Rsa(_) => &[0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x0b],
         }
     }
+
+    /// An RSA or EC private key from a PEM-encoded PKCS#8 (`-----BEGIN PRIVATE
+    /// KEY-----`) or PKCS#1 (`-----BEGIN RSA PRIVATE KEY-----`) block.
+    pub fn from_pem(pem: &[u8]) -> Result<Self> {
+        if let Ok(der) = pem_decode(pem, "PRIVATE KEY") {
+            return Self::from_pkcs8_der(&der);
+        }
+        if let Ok(der) = pem_decode(pem, "RSA PRIVATE KEY") {
+            return Self::rsa_from_pkcs1_der(&der);
+        }
+        Err(invalid_data("PEM key is neither PKCS#8 PRIVATE KEY nor RSA PRIVATE KEY").into())
+    }
+
+    /// An RSA private key from a PEM-encoded PKCS#1 block.
+    pub fn rsa_from_pkcs1_pem(pem: &[u8]) -> Result<Self> {
+        let der = pem_decode(pem, "RSA PRIVATE KEY")?;
+        Self::rsa_from_pkcs1_der(&der)
+    }
+
+    /// An RSA or EC private key from a PEM-encoded PKCS#8 block.
+    pub fn from_pkcs8_pem(pem: &[u8]) -> Result<Self> {
+        let der = pem_decode(pem, "PRIVATE KEY")?;
+        Self::from_pkcs8_der(&der)
+    }
+}
+
+/// Decode a PEM block, returning the DER bytes of the body. `expected_tag` is
+/// the label inside the `-----BEGIN <tag>-----`/`-----END <tag>-----` envelope
+/// (e.g. `"PRIVATE KEY"`, `"CERTIFICATE"`). Hand-rolled base64 keeps this
+/// C-dependency-free.
+pub fn pem_decode(pem: &[u8], expected_tag: &str) -> Result<Vec<u8>> {
+    let text = std::str::from_utf8(pem).map_err(|_| invalid_data("PEM is not valid UTF-8"))?;
+    let begin = format!("-----BEGIN {expected_tag}-----");
+    let end = format!("-----END {expected_tag}-----");
+    let start = text
+        .find(&begin)
+        .ok_or_else(|| invalid_data(&format!("PEM missing BEGIN {expected_tag}")))?;
+    let body_start = start + begin.len();
+    let end_pos = text[body_start..]
+        .find(&end)
+        .ok_or_else(|| invalid_data(&format!("PEM missing END {expected_tag}")))?
+        + body_start;
+    let b64: String = text[body_start..end_pos]
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect();
+    base64_decode(b64.as_bytes())
+}
+
+/// Decode a base64 string to bytes (standard alphabet with padding).
+fn base64_decode(input: &[u8]) -> Result<Vec<u8>> {
+    const TABLE: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut bits: u32 = 0;
+    let mut count = 0u32;
+    let mut out = Vec::with_capacity(input.len() * 3 / 4);
+    for &b in input {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'+' | b'/' => {
+                let val = TABLE.iter().position(|&t| t == b).unwrap() as u32;
+                bits = (bits << 6) | val;
+                count += 6;
+                if count >= 8 {
+                    count -= 8;
+                    out.push((bits >> count) as u8);
+                }
+            }
+            b'=' => break,
+            _ => return Err(invalid_data("invalid base64 character").into()),
+        }
+    }
+    Ok(out)
+}
+
+/// The signature dictionary `/SubFilter` — the CMS flavor.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum SubFilter {
+    /// `adbe.pkcs7.detached` — the classic Adobe detached PKCS#7 (default).
+    #[default]
+    AdbePkcs7Detached,
+    /// `ETSI.CAdES.detached` — PAdES B-B level (RFC 5126), recognized by zpdf's
+    /// verifier and standard PAdES viewers. Same CMS content as detached; the
+    /// SubFilter name is what makes it PAdES.
+    EtsiCAdESDetached,
+}
+
+impl SubFilter {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            SubFilter::AdbePkcs7Detached => "adbe.pkcs7.detached",
+            SubFilter::EtsiCAdESDetached => "ETSI.CAdES.detached",
+        }
+    }
+}
+
+/// A visible signature appearance: a non-zero `/Rect` widget with a rendered
+/// `/AP /N` Form XObject (signer name, date, reason; optional background and
+/// border). When `None`, the signature is invisible (the original behavior).
+#[derive(Debug, Clone)]
+pub struct AppearanceSpec {
+    /// The widget rectangle in page coordinates (PDF user space, origin bottom-left).
+    pub rect: zpdf_core::Rect,
+    /// Render the signer's `/Name` and `/Reason` text inside the appearance.
+    pub show_text: bool,
+    /// Render the signing `/M` date inside the appearance.
+    pub show_date: bool,
+    /// Fill color (RGB, 0–1); `None` for no fill.
+    pub bg: Option<(f64, f64, f64)>,
+    /// Border color (RGB, 0–1); `None` for no border.
+    pub border: Option<(f64, f64, f64)>,
+}
+
+impl Default for AppearanceSpec {
+    fn default() -> Self {
+        Self {
+            rect: zpdf_core::Rect::new(20.0, 20.0, 220.0, 60.0),
+            show_text: true,
+            show_date: true,
+            bg: Some((0.96, 0.97, 0.99)),
+            border: Some((0.4, 0.5, 0.7)),
+        }
+    }
+}
+
+/// A pluggable RFC 3161 timestamp requester. The signer builds a
+/// `TimeStampReq` (SHA-256 over the signature value), the requester fetches a
+/// `TimeStampResp` from a TSA, and the signer embeds the timestamp token as a
+/// CMS `unsignedAttr`. The library has no network dependency by default; opt
+/// into the built-in ureq implementation with the `timestamp` feature.
+pub trait TimestampRequester {
+    /// POST a `TimeStampReq` (DER) and return the `TimeStampResp` (DER).
+    fn request_timestamp(&self, time_stamp_req_der: &[u8]) -> Result<Vec<u8>>;
+}
+
+/// A `TimestampRequester` over HTTP(S) using the pure-Rust `ureq` client
+/// (behind the `timestamp` feature). POSTs the request to the TSA URL with
+/// `Content-Type: application/timestamp-query`.
+#[cfg(feature = "timestamp")]
+pub struct UreqTimestampRequester {
+    tsa_url: String,
+}
+
+#[cfg(feature = "timestamp")]
+impl UreqTimestampRequester {
+    /// Create a requester for a TSA endpoint (e.g.
+    /// `http://timestamp.digicert.com`).
+    pub fn new(tsa_url: String) -> Self {
+        Self { tsa_url }
+    }
+}
+
+#[cfg(feature = "timestamp")]
+impl TimestampRequester for UreqTimestampRequester {
+    fn request_timestamp(&self, time_stamp_req_der: &[u8]) -> Result<Vec<u8>> {
+        use std::io::Read;
+        let resp = ureq::post(&self.tsa_url)
+            .set("Content-Type", "application/timestamp-query")
+            .send_bytes(time_stamp_req_der)
+            .map_err(|e| invalid_data(&format!("TSA request failed: {e}")))?;
+        let mut bytes = Vec::new();
+        resp.into_reader()
+            .read_to_end(&mut bytes)
+            .map_err(|e| invalid_data(&format!("TSA response read failed: {e}")))?;
+        Ok(bytes)
+    }
 }
 
 /// Optional signature metadata written into the signature dictionary.
-#[derive(Debug, Clone, Default)]
+#[derive(Default)]
 pub struct SignatureOptions {
     /// `/Name` — the signer's name.
     pub name: Option<String>,
@@ -114,6 +278,35 @@ pub struct SignatureOptions {
     pub contact: Option<String>,
     /// Field name (`/T`); default `Signature1`.
     pub field_name: Option<String>,
+    /// The `/SubFilter` (CMS flavor). Defaults to `adbe.pkcs7.detached`.
+    pub subfilter: SubFilter,
+    /// A visible signature appearance; `None` for an invisible signature.
+    pub appearance: Option<AppearanceSpec>,
+    /// Additional certificates to embed in the CMS `certificates` set (e.g.
+    /// the chain up to the root), enabling trust verification and DSS/LTV.
+    pub extra_certs: Vec<Vec<u8>>,
+    /// CRLs to embed in the CMS `crls` set for offline revocation checking.
+    pub crls: Vec<Vec<u8>>,
+    /// An RFC 3161 timestamp requester; when present, a timestamp token is
+    /// fetched over the signature and embedded as a CMS `unsignedAttr`.
+    pub timestamp: Option<Box<dyn TimestampRequester>>,
+}
+
+impl Clone for SignatureOptions {
+    fn clone(&self) -> Self {
+        Self {
+            name: self.name.clone(),
+            reason: self.reason.clone(),
+            location: self.location.clone(),
+            contact: self.contact.clone(),
+            field_name: self.field_name.clone(),
+            subfilter: self.subfilter,
+            appearance: self.appearance.clone(),
+            extra_certs: self.extra_certs.clone(),
+            crls: self.crls.clone(),
+            timestamp: None, // the requester is not Cloneable; clone without it
+        }
+    }
 }
 
 impl IncrementalWriter {
@@ -138,7 +331,11 @@ impl IncrementalWriter {
         let field_name = options.field_name.as_deref().unwrap_or("Signature1");
         let mut sig_body = Vec::new();
         sig_body.extend_from_slice(
-            b"<< /Type /Sig /Filter /Adobe.PPKLite /SubFilter /adbe.pkcs7.detached",
+            format!(
+                "<< /Type /Sig /Filter /Adobe.PPKLite /SubFilter /{}",
+                options.subfilter.as_str()
+            )
+            .as_bytes(),
         );
         for (k, v) in [
             ("Name", &options.name),
@@ -175,20 +372,139 @@ impl IncrementalWriter {
             PdfName::new("Subtype"),
             PdfObject::Name(PdfName::new("Widget")),
         );
-        // Invisible: zero rect + Hidden=0, Print flag set (bit 3, value 4).
-        field.insert(
-            PdfName::new("Rect"),
-            PdfObject::Array(vec![
-                PdfObject::Integer(0),
-                PdfObject::Integer(0),
-                PdfObject::Integer(0),
-                PdfObject::Integer(0),
-            ]),
-        );
-        field.insert(PdfName::new("F"), PdfObject::Integer(4));
         field.insert(PdfName::new("P"), PdfObject::Ref(page_id));
+
+        if let Some(appearance) = &options.appearance {
+            // Visible signature: a non-zero /Rect widget with a rendered
+            // /AP /N Form XObject (signer name, date, reason, background,
+            // border) plus /MK appearance characteristics and a /DA.
+            let r = &appearance.rect;
+            field.insert(
+                PdfName::new("Rect"),
+                PdfObject::Array(vec![
+                    PdfObject::Real(r.x0),
+                    PdfObject::Real(r.y0),
+                    PdfObject::Real(r.x1),
+                    PdfObject::Real(r.y1),
+                ]),
+            );
+            field.insert(PdfName::new("F"), PdfObject::Integer(4)); // Print
+            let (content, w, h) = build_appearance_stream(
+                appearance,
+                options.name.as_deref().unwrap_or(""),
+                options.reason.as_deref().unwrap_or(""),
+            );
+            let mut ap_dict = PdfDict::new();
+            ap_dict.insert(
+                PdfName::new("Type"),
+                PdfObject::Name(PdfName::new("XObject")),
+            );
+            ap_dict.insert(
+                PdfName::new("Subtype"),
+                PdfObject::Name(PdfName::new("Form")),
+            );
+            ap_dict.insert(
+                PdfName::new("BBox"),
+                PdfObject::Array(vec![
+                    PdfObject::Integer(0),
+                    PdfObject::Integer(0),
+                    PdfObject::Real(w),
+                    PdfObject::Real(h),
+                ]),
+            );
+            // The appearance uses a standard-14 Helvetica for its text.
+            let mut res = PdfDict::new();
+            let mut fonts = PdfDict::new();
+            let mut helv = PdfDict::new();
+            helv.insert(PdfName::new("Type"), PdfObject::Name(PdfName::new("Font")));
+            helv.insert(
+                PdfName::new("Subtype"),
+                PdfObject::Name(PdfName::new("Type1")),
+            );
+            helv.insert(
+                PdfName::new("BaseFont"),
+                PdfObject::Name(PdfName::new("Helvetica")),
+            );
+            fonts.insert(PdfName::new("Helv"), PdfObject::Dict(helv));
+            res.insert(PdfName::new("Font"), PdfObject::Dict(fonts));
+            ap_dict.insert(PdfName::new("Resources"), PdfObject::Dict(res));
+            let (ap_num, _) = self.try_add_stream(&ap_dict, &content)?;
+            let mut ap = PdfDict::new();
+            ap.insert(PdfName::new("N"), PdfObject::Ref(ObjectId(ap_num, 0)));
+            field.insert(PdfName::new("AP"), PdfObject::Dict(ap));
+            // /MK appearance characteristics: background, border, caption.
+            let mut mk = PdfDict::new();
+            if let Some((br, bg, bb)) = appearance.border {
+                mk.insert(
+                    PdfName::new("BC"),
+                    PdfObject::Array(vec![
+                        PdfObject::Real(br),
+                        PdfObject::Real(bg),
+                        PdfObject::Real(bb),
+                    ]),
+                );
+            }
+            if let Some((r2, g2, b2)) = appearance.bg {
+                mk.insert(
+                    PdfName::new("BG"),
+                    PdfObject::Array(vec![
+                        PdfObject::Real(r2),
+                        PdfObject::Real(g2),
+                        PdfObject::Real(b2),
+                    ]),
+                );
+            }
+            mk.insert(
+                PdfName::new("CA"),
+                PdfObject::String(encode_text_string("Signature")),
+            );
+            field.insert(PdfName::new("MK"), PdfObject::Dict(mk));
+            field.insert(
+                PdfName::new("DA"),
+                PdfObject::String(encode_text_string("0 0 0 rg /Helv 9 Tf")),
+            );
+        } else {
+            // Invisible: zero rect + Print flag set (bit 3, value 4).
+            field.insert(
+                PdfName::new("Rect"),
+                PdfObject::Array(vec![
+                    PdfObject::Integer(0),
+                    PdfObject::Integer(0),
+                    PdfObject::Integer(0),
+                    PdfObject::Integer(0),
+                ]),
+            );
+            field.insert(PdfName::new("F"), PdfObject::Integer(4));
+        }
         let (field_num, _) = self.try_add_object(&PdfObject::Dict(field))?;
         let field_ref = ObjectId(field_num, 0);
+
+        // --- 2b. DSS (Document Security Store): embed extra certs + CRLs for
+        // LTV / offline validation. /VRI is omitted (optional); /Certs and
+        // /CRLs carry the caller-supplied validation material.
+        let dss_ref = if !options.extra_certs.is_empty() || !options.crls.is_empty() {
+            let mut cert_refs = Vec::new();
+            for cert in &options.extra_certs {
+                let (n, _) = self.try_add_stream(&PdfDict::new(), cert)?;
+                cert_refs.push(PdfObject::Ref(ObjectId(n, 0)));
+            }
+            let mut crl_refs = Vec::new();
+            for crl in &options.crls {
+                let (n, _) = self.try_add_stream(&PdfDict::new(), crl)?;
+                crl_refs.push(PdfObject::Ref(ObjectId(n, 0)));
+            }
+            let mut dss = PdfDict::new();
+            if !cert_refs.is_empty() {
+                dss.insert(PdfName::new("Certs"), PdfObject::Array(cert_refs));
+            }
+            if !crl_refs.is_empty() {
+                dss.insert(PdfName::new("CRLs"), PdfObject::Array(crl_refs));
+            }
+            let (dss_num, _) = self.try_add_object(&PdfObject::Dict(dss))?;
+            Some(ObjectId(dss_num, 0))
+        } else {
+            None
+        };
 
         // --- 3. Wire into the page /Annots and the AcroForm /Fields.
         let page_obj = self.resolve_current(page_id)?;
@@ -236,6 +552,14 @@ impl IncrementalWriter {
                 self.overwrite_object(catalog_id, PdfObject::Dict(catalog_dict));
             }
         }
+        // Attach the /DSS to the catalog (re-resolve so the AcroForm overwrite
+        // above, if any, is preserved).
+        if let Some(dss) = dss_ref {
+            let catalog = self.resolve_current(catalog_id)?;
+            let mut catalog_dict = catalog.as_dict()?.clone();
+            catalog_dict.insert(PdfName::new("DSS"), PdfObject::Ref(dss));
+            self.overwrite_object(catalog_id, PdfObject::Dict(catalog_dict));
+        }
 
         // --- 4. Serialize, patch /ByteRange, hash, patch /Contents.
         let mut cursor = std::io::Cursor::new(Vec::new());
@@ -278,7 +602,35 @@ impl IncrementalWriter {
         hasher.update(&buf[contents_end..]);
         let digest = hasher.finalize();
 
-        let cms = build_cms(&digest, certificate_der, key)?;
+        // Two-phase CMS: compute the signature over the signed attributes
+        // first, then (optionally) fetch an RFC 3161 timestamp over the
+        // signature value and embed it as an unsignedAttr, before assembling
+        // the final SignedData.
+        let signed_attrs = build_signed_attrs(&digest);
+        let signature = key.sign(&der(SET, &signed_attrs))?;
+
+        let unsigned_attrs: Option<Vec<u8>> = if let Some(requester) = &options.timestamp {
+            // Hash the signature value for the TimeStampReq messageImprint.
+            let sig_hash = Sha256::digest(&signature);
+            let tsq = build_time_stamp_req(&sig_hash)?;
+            let tsr = requester.request_timestamp(&tsq)?;
+            let tst = extract_time_stamp_token(&tsr).ok_or_else(|| {
+                invalid_data("TSA returned no timestamp token (status error or missing token)")
+            })?;
+            Some(build_unsigned_attrs_timestamp(&tst))
+        } else {
+            None
+        };
+
+        let cms = build_cms(
+            certificate_der,
+            &options.extra_certs,
+            &options.crls,
+            &signed_attrs,
+            &signature,
+            key.sig_alg_oid(),
+            unsigned_attrs.as_deref(),
+        );
         let hex = to_hex(&cms);
         if hex.len() > RESERVED_HEX {
             return Err(invalid_data("CMS exceeds the reserved /Contents window").into());
@@ -296,6 +648,7 @@ const OID: u8 = 0x06;
 const OCTET: u8 = 0x04;
 const INT: u8 = 0x02;
 const CTX0: u8 = 0xA0;
+const CTX1: u8 = 0xA1;
 
 const OID_SHA256: &[u8] = &[0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x01];
 const OID_CONTENT_TYPE: &[u8] = &[0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x09, 0x03];
@@ -324,13 +677,12 @@ fn der(tag: u8, content: &[u8]) -> Vec<u8> {
     out
 }
 
-/// Build the detached CMS `SignedData` over `digest` (the SHA-256 of the
-/// signed byte ranges), embedding `cert` and signing with `key`.
-fn build_cms(digest: &[u8], cert: &[u8], key: &SigningKey) -> Result<Vec<u8>> {
-    let digest_alg = der(SEQ, &der(OID, OID_SHA256));
-
-    // Signed attributes: contentType(data) then messageDigest — this is also
-    // their DER SET-of lexicographic order (identical prefixes; 0x03 < 0x04).
+/// Build the signed-attributes SET body (contentType(data) then
+/// messageDigest), in their DER SET-of lexicographic order. The returned
+/// bytes are the concatenation of the two attribute SEQUENCEs — used both as
+/// the IMPLICIT `[0]` signedAttrs content and (wrapped in a SET) as the data
+/// the signature covers.
+fn build_signed_attrs(digest: &[u8]) -> Vec<u8> {
     let ct_attr = der(
         SEQ,
         &[der(OID, OID_CONTENT_TYPE), der(SET, &der(OID, OID_DATA))].concat(),
@@ -339,39 +691,172 @@ fn build_cms(digest: &[u8], cert: &[u8], key: &SigningKey) -> Result<Vec<u8>> {
         SEQ,
         &[der(OID, OID_MESSAGE_DIGEST), der(SET, &der(OCTET, digest))].concat(),
     );
-    let attrs = [ct_attr, md_attr].concat();
+    [ct_attr, md_attr].concat()
+}
 
-    // The signature covers the SET-encoded attributes (RFC 5652 §5.4); the
-    // CMS itself stores the [0] IMPLICIT form.
-    let signature = key.sign(&der(SET, &attrs))?;
+/// Build the detached CMS `SignedData` over `digest` (the SHA-256 of the
+/// signed byte ranges), embedding the signer cert plus any `extra_certs`
+/// (chain) and `crls`, carrying pre-computed `signed_attrs` and `signature`,
+/// and an optional `unsigned_attrs` (RFC 3161 timestamp token).
+fn build_cms(
+    signer_cert: &[u8],
+    extra_certs: &[Vec<u8>],
+    crls: &[Vec<u8>],
+    signed_attrs: &[u8],
+    signature: &[u8],
+    sig_alg_oid: &[u8],
+    unsigned_attrs: Option<&[u8]>,
+) -> Vec<u8> {
+    let digest_alg = der(SEQ, &der(OID, OID_SHA256));
 
-    let signer_info = der(
-        SEQ,
-        &[
-            der(INT, &[1]),
-            der(SEQ, &[]), // sid: not read by verifiers that scan by OID
-            digest_alg.clone(),
-            der(CTX0, &attrs), // signedAttrs [0] IMPLICIT
-            der(SEQ, &der(OID, key.sig_alg_oid())),
-            der(OCTET, &signature),
-        ]
-        .concat(),
-    );
-    let signed_data = der(
-        SEQ,
-        &[
-            der(INT, &[1]),
-            der(SET, &digest_alg),
-            der(SEQ, &der(OID, OID_DATA)),
-            der(CTX0, cert), // certificates [0] IMPLICIT
-            der(SET, &signer_info),
-        ]
-        .concat(),
-    );
-    Ok(der(
+    // certificates [0] IMPLICIT: signer cert first, then the chain.
+    let mut certs_blob = signer_cert.to_vec();
+    for c in extra_certs {
+        certs_blob.extend_from_slice(c);
+    }
+    let certificates = der(CTX0, &certs_blob);
+
+    // crls [1] IMPLICIT (optional).
+    let mut crls_blob = Vec::new();
+    for c in crls {
+        crls_blob.extend_from_slice(c);
+    }
+    let crls_field = if crls_blob.is_empty() {
+        Vec::new()
+    } else {
+        der(CTX1, &crls_blob)
+    };
+
+    let mut signer_info_fields = vec![
+        der(INT, &[1]),
+        der(SEQ, &[]), // sid: not read by verifiers that scan by OID
+        digest_alg.clone(),
+        der(CTX0, signed_attrs), // signedAttrs [0] IMPLICIT
+        der(SEQ, &der(OID, sig_alg_oid)),
+        der(OCTET, signature),
+    ];
+    if let Some(ua) = unsigned_attrs {
+        signer_info_fields.push(der(CTX1, ua)); // unsignedAttrs [1] IMPLICIT
+    }
+    let signer_info = der(SEQ, &signer_info_fields.concat());
+
+    let mut sd_fields = vec![
+        der(INT, &[1]),
+        der(SET, &digest_alg),
+        der(SEQ, &der(OID, OID_DATA)),
+        certificates,
+    ];
+    if !crls_field.is_empty() {
+        sd_fields.push(crls_field);
+    }
+    sd_fields.push(der(SET, &signer_info));
+    let signed_data = der(SEQ, &sd_fields.concat());
+
+    der(
         SEQ,
         &[der(OID, OID_SIGNED_DATA), der(CTX0, &signed_data)].concat(),
-    ))
+    )
+}
+
+/// OID for the CMS `signature-time-stamp` signed/unsigned attribute
+/// (1.2.840.113549.1.9.16.2.14).
+const OID_SIGNATURE_TIME_STAMP: &[u8] = &[
+    0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x09, 0x10, 0x02, 0x0e,
+];
+
+/// Build the `unsignedAttrs` SET body carrying a `signature-time-stamp`
+/// attribute whose value is the timestamp token (a ContentInfo). `tst` is the
+/// full ContentInfo TLV extracted from the TSA's TimeStampResp.
+fn build_unsigned_attrs_timestamp(tst: &[u8]) -> Vec<u8> {
+    der(
+        SEQ,
+        &[der(OID, OID_SIGNATURE_TIME_STAMP), der(SET, tst)].concat(),
+    )
+}
+
+/// Build an RFC 3161 `TimeStampReq` over the SHA-256 of the signature value,
+/// with a fresh nonce and `certReq = true` (ask the TSA to include its cert).
+fn build_time_stamp_req(signature_hash: &[u8]) -> Result<Vec<u8>> {
+    let mut nonce = [0u8; 8];
+    getrandom::getrandom(&mut nonce)
+        .map_err(|_| invalid_data("getrandom failed for timestamp nonce"))?;
+    let message_imprint = der(
+        SEQ,
+        &[der(SEQ, &der(OID, OID_SHA256)), der(OCTET, signature_hash)].concat(),
+    );
+    let req = der(
+        SEQ,
+        &[
+            der(INT, &[1]),
+            message_imprint,
+            der(INT, &nonce),
+            der(0x01, &[0xff]), // certReq BOOLEAN TRUE
+        ]
+        .concat(),
+    );
+    Ok(req)
+}
+
+/// Extract the `timeStampToken` (a ContentInfo TLV) from a `TimeStampResp`.
+/// Returns the full ContentInfo bytes (tag + length + value) to embed as the
+/// unsigned attribute value. `None` when the response carries no token (TSA
+/// error or missing token).
+fn extract_time_stamp_token(tsr: &[u8]) -> Option<Vec<u8>> {
+    // TimeStampResp ::= SEQUENCE { status PKIStatusInfo, timeStampToken? ContentInfo }
+    let (outer_tag, outer_content) = tlv_split(tsr)?;
+    if outer_tag != SEQ {
+        return None;
+    }
+    let mut rest = outer_content;
+    let mut idx = 0;
+    while !rest.is_empty() {
+        let total = tlv_total_len(rest);
+        if idx == 1 {
+            // Second child is the timeStampToken ContentInfo.
+            return Some(rest[..total].to_vec());
+        }
+        idx += 1;
+        rest = &rest[total..];
+    }
+    None
+}
+
+/// (tag, content) of the DER TLV at the start of `bytes`.
+fn tlv_split(bytes: &[u8]) -> Option<(u8, &[u8])> {
+    let &tag = bytes.first()?;
+    let len_byte = *bytes.get(1)?;
+    let (len, header) = if len_byte < 0x80 {
+        (len_byte as usize, 2)
+    } else {
+        let n = (len_byte & 0x7f) as usize;
+        if !(1..=4).contains(&n) || bytes.len() < 2 + n {
+            return None;
+        }
+        let mut l = 0usize;
+        for i in 0..n {
+            l = (l << 8) | bytes[2 + i] as usize;
+        }
+        (l, 2 + n)
+    };
+    let content = bytes.get(header..header + len)?;
+    Some((tag, content))
+}
+
+/// Total byte length of the TLV at the start of `bytes` (header + content).
+fn tlv_total_len(bytes: &[u8]) -> usize {
+    let Some((_, content)) = tlv_split(bytes) else {
+        return bytes.len();
+    };
+    let len_byte = match bytes.get(1) {
+        Some(&b) => b,
+        None => return bytes.len(),
+    };
+    let header = if len_byte < 0x80 {
+        2
+    } else {
+        2 + (len_byte & 0x7f) as usize
+    };
+    header + content.len()
 }
 
 fn to_hex(bytes: &[u8]) -> Vec<u8> {
@@ -395,4 +880,63 @@ fn find_from(haystack: &[u8], needle: &[u8], from: usize) -> Option<usize> {
 /// `YYYYMMDDHHMMSS` (UTC) for the signature `/M` date.
 fn pdf_timestamp() -> String {
     crate::metadata::pdf_date_now_raw()
+}
+
+/// Build a visible-signature appearance Form XObject content stream in the
+/// XObject's own `[0 0 w h]` coordinate space: an optional filled background,
+/// an optional stroked border, and up to three lines of text (signer name,
+/// reason, signing date) set in standard-14 Helvetica 9pt. Returns the
+/// content bytes plus the (width, height) the caller should use as the
+/// XObject `/BBox`.
+fn build_appearance_stream(spec: &AppearanceSpec, name: &str, reason: &str) -> (Vec<u8>, f64, f64) {
+    let w = (spec.rect.x1 - spec.rect.x0).max(1.0);
+    let h = (spec.rect.y1 - spec.rect.y0).max(1.0);
+    let mut ops = Vec::new();
+    ops.extend_from_slice(b"q\n");
+    if let Some((r, g, b)) = spec.bg {
+        ops.extend_from_slice(format!("{r} {g} {b} rg 0 0 {w} {h} re f\n").as_bytes());
+    }
+    if let Some((r, g, b)) = spec.border {
+        ops.extend_from_slice(format!("{r} {g} {b} RG 1 w 0 0 {w} {h} re S\n").as_bytes());
+    }
+    if spec.show_text || spec.show_date {
+        ops.extend_from_slice(b"BT\n/Helv 9 Tf 0 0 0 rg\n");
+        let mut y = h - 14.0;
+        if spec.show_text && !name.is_empty() {
+            ops.extend_from_slice(format!("1 0 0 1 8 {y} Tm (").as_bytes());
+            escape_appearance_text(name, &mut ops);
+            ops.extend_from_slice(b") Tj\n");
+            y -= 12.0;
+        }
+        if spec.show_text && !reason.is_empty() {
+            ops.extend_from_slice(format!("1 0 0 1 8 {y} Tm (").as_bytes());
+            escape_appearance_text(reason, &mut ops);
+            ops.extend_from_slice(b") Tj\n");
+            y -= 12.0;
+        }
+        if spec.show_date {
+            let date = pdf_timestamp();
+            ops.extend_from_slice(format!("1 0 0 1 8 {y} Tm (").as_bytes());
+            escape_appearance_text(&date, &mut ops);
+            ops.extend_from_slice(b") Tj\n");
+        }
+        ops.extend_from_slice(b"ET\n");
+    }
+    ops.extend_from_slice(b"Q\n");
+    (ops, w, h)
+}
+
+/// Escape a string into a PDF literal-string body, WinAnsi-ish-encoding each
+/// char (code points > 0xFF fall back to `?`).
+fn escape_appearance_text(s: &str, out: &mut Vec<u8>) {
+    for ch in s.chars() {
+        let b = if (ch as u32) <= 0xFF { ch as u8 } else { b'?' };
+        match b {
+            b'\\' => out.extend_from_slice(b"\\\\"),
+            b'(' => out.extend_from_slice(b"\\("),
+            b')' => out.extend_from_slice(b"\\)"),
+            b'\r' => out.extend_from_slice(b"\\r"),
+            _ => out.push(b),
+        }
+    }
 }

--- a/crates/zpdf-writer/src/subset.rs
+++ b/crates/zpdf-writer/src/subset.rs
@@ -159,7 +159,7 @@ fn composite_components(data: &[u8]) -> Vec<u16> {
 
 /// Reassemble the sfnt with some tables replaced. `force_long_loca` writes
 /// `indexToLocFormat = 1` into the copied `head`.
-fn rebuild_sfnt(
+pub(crate) fn rebuild_sfnt(
     font: &[u8],
     replacements: &[([u8; 4], Vec<u8>)],
     force_long_loca: bool,

--- a/crates/zpdf-writer/src/tounicode.rs
+++ b/crates/zpdf-writer/src/tounicode.rs
@@ -1,0 +1,141 @@
+//! `/ToUnicode` CMap serialization for the writer.
+//!
+//! The read side parses ToUnicode CMaps (`zpdf_font::cmap::ToUnicodeMap`); this
+//! is the inverse — build the CMap stream bytes that map a font's 2-byte codes
+//! (GIDs, under Identity-H) back to UTF-16BE Unicode so viewers can extract
+//! text. Output is a conformant CMap with `begincodespacerange` /
+//! `beginbfrange` / `beginbfchar`, packed 100 entries per block (the CMap
+//! spec's per-block ceiling) and with run-encoded ranges where GID and
+//! Unicode advance together (the common CJK case, where consecutive CJK code
+//! points map to consecutive GIDs in a cmap subtable).
+
+/// Build a `/ToUnicode` CMap stream body from `gid → Unicode scalar` pairs.
+///
+/// `mappings` is `(code, char)` where `code` is the 2-byte value emitted in
+/// the content stream (the GID under Identity-H). Surrogate pairs are emitted
+/// for scalars outside the BMP so the result is correct for any plane.
+pub(crate) fn build_tounicode_cmap(mappings: &[(u16, char)]) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(
+        b"/CIDInit /ProcSet findresource begin\n12 dict begin\nbegincmap\n\
+         /CIDSystemInfo << /Registry (Adobe) /Ordering (UCS) /Supplement 0 >> def\n\
+         /CMapName /Adobe-Identity-UCS def\n/CMapType 2 def\n",
+    );
+    out.extend_from_slice(b"1 begincodespacerange\n<0000> <FFFF>\nendcodespacerange\n");
+
+    // Split into runs (consecutive code, consecutive Unicode) and singletons.
+    let mut sorted: Vec<(u16, char)> = mappings.to_vec();
+    sorted.sort_unstable_by_key(|&(c, _)| c);
+    sorted.dedup_by_key(|(c, _)| *c);
+
+    let mut ranges: Vec<(u16, u16, char)> = Vec::new(); // (lo, hi, start_char)
+    let mut singles: Vec<(u16, char)> = Vec::new();
+    let mut i = 0;
+    while i < sorted.len() {
+        let (lo, ch) = sorted[i];
+        let start_cp = ch as u32;
+        let mut hi = lo;
+        let mut j = i + 1;
+        while j < sorted.len() {
+            let (cj, chj) = sorted[j];
+            if cj == hi.saturating_add(1) && (chj as u32) == start_cp + (cj - lo) as u32 {
+                hi = cj;
+                j += 1;
+            } else {
+                break;
+            }
+        }
+        if hi > lo {
+            ranges.push((lo, hi, ch));
+        } else {
+            singles.push((lo, ch));
+        }
+        i = j;
+    }
+
+    // Emit ranges in blocks of 100. A bfrange `<lo> <hi> <start>` maps lo+k →
+    // start+k (the parser increments the destination); we only grouped runs
+    // whose Unicode advances in lockstep with the code, so the single start
+    // value suffices.
+    for chunk in ranges.chunks(100) {
+        out.extend_from_slice(format!("{} beginbfrange\n", chunk.len()).as_bytes());
+        for &(lo, hi, ch) in chunk {
+            out.extend_from_slice(format!("<{lo:04X}> <{hi:04X}> <").as_bytes());
+            write_utf16_hex(&mut out, ch as u32);
+            out.extend_from_slice(b">\n");
+        }
+        out.extend_from_slice(b"endbfrange\n");
+    }
+
+    // Emit singletons in blocks of 100.
+    for chunk in singles.chunks(100) {
+        out.extend_from_slice(format!("{} beginbfchar\n", chunk.len()).as_bytes());
+        for &(code, ch) in chunk {
+            out.extend_from_slice(format!("<{code:04X}> <").as_bytes());
+            write_utf16_hex(&mut out, ch as u32);
+            out.extend_from_slice(b">\n");
+        }
+        out.extend_from_slice(b"endbfchar\n");
+    }
+
+    out.extend_from_slice(b"endcmap\nCMapName currentdict /CMap defineresource pop\nend\nend\n");
+    out
+}
+
+/// Write `code_point` as UTF-16BE **hex digits** into `out` (4 hex digits for
+/// BMP, 8 for a supplementary-plane surrogate pair). CMap `<bfchar>`/`<bfrange>`
+/// values are hex strings, so this emits ASCII hex, not the raw bytes.
+fn write_utf16_hex(out: &mut Vec<u8>, code_point: u32) {
+    let mut buf = [0u16; 2];
+    let s: &[u16] = match char::from_u32(code_point) {
+        Some(c) => c.encode_utf16(&mut buf),
+        None => &buf[..0],
+    };
+    for &u in s {
+        out.extend_from_slice(format!("{u:04X}").as_bytes());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bmp_singleton_round_trips_through_parser() {
+        let cmap = build_tounicode_cmap(&[(65, 'A')]);
+        let parsed = zpdf_font::cmap::ToUnicodeMap::parse(&cmap);
+        assert_eq!(parsed.lookup(65), Some("A"));
+    }
+
+    #[test]
+    fn cjk_range_packs_into_bfrange() {
+        // Consecutive GIDs 100..103 mapping to consecutive CJK code points.
+        let mappings = vec![
+            (100, '\u{4E00}'),
+            (101, '\u{4E01}'),
+            (102, '\u{4E02}'),
+            (103, '\u{4E03}'),
+        ];
+        let cmap = build_tounicode_cmap(&mappings);
+        let body = String::from_utf8_lossy(&cmap);
+        assert!(body.contains("beginbfrange"), "body: {body}");
+        assert!(
+            !body.contains("beginbfchar"),
+            "expected no singletons: {body}"
+        );
+        let parsed = zpdf_font::cmap::ToUnicodeMap::parse(&cmap);
+        for (gid, ch) in &mappings {
+            assert_eq!(parsed.lookup(*gid as u32), Some(ch.to_string().as_str()));
+        }
+    }
+
+    #[test]
+    fn supplementary_plane_emits_surrogate_pair() {
+        // U+1F600 (emoji) — outside the BMP, must serialize as a surrogate pair.
+        let cmap = build_tounicode_cmap(&[(1, '\u{1F600}')]);
+        let body = String::from_utf8_lossy(&cmap);
+        assert!(body.contains("<D83DDE00>"), "body: {body}");
+        let parsed = zpdf_font::cmap::ToUnicodeMap::parse(&cmap);
+        assert_eq!(parsed.lookup(1), Some("\u{1F600}"));
+    }
+}

--- a/crates/zpdf-writer/tests/cjk.rs
+++ b/crates/zpdf-writer/tests/cjk.rs
@@ -1,0 +1,188 @@
+//! CJK-capable authoring round-trip: embed a font as a Type0/Identity-H
+//! composite font, write text, and read it back through the document/font
+//! pipeline.
+//!
+//! `var.ttf` (the committed Latin variable-font fixture) is tiny and lacks
+//! most glyphs, so it is used only for the always-on structural and
+//! classification assertions. The load-bearing round-trip uses a real embedded
+//! CJK font program pulled from the committed local corpus (`tests/test1/1.pdf`)
+//! — skipped if the corpus is absent.
+
+use zpdf_core::PdfObject;
+use zpdf_document::PdfDocument;
+use zpdf_writer::{classify_font_program, DocumentBuilder, FontProgram};
+
+const VAR_TTF: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../crates/zpdf-font/tests/fixtures/var.ttf"
+);
+const CJK_CORPUS: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../../tests/test1/1.pdf");
+
+/// Extract text from page 0 by running the content interpreter with a text
+/// sink (the same path the `zpdf text` CLI uses), then collapsing the spans.
+fn page0_text(pdf: &[u8]) -> String {
+    let doc = PdfDocument::open(pdf.to_vec()).expect("open PDF");
+    let page = doc.page(0).expect("page 0");
+    let mut font_cache = doc.load_page_fonts(&page);
+    let content = doc.page_content_bytes(&page).expect("content bytes");
+    let mut spans: Vec<zpdf_content::text::TextSpan> = Vec::new();
+    {
+        let interp = zpdf_content::interpreter::ContentInterpreter::new(page.effective_box())
+            .with_fonts(&mut font_cache)
+            .with_document(doc.file(), &page.resources)
+            .with_text_sink(&mut spans);
+        let _ = interp.interpret(&content);
+    }
+    zpdf_content::text::spans_to_text(spans, 2.0)
+}
+
+#[test]
+fn classify_var_ttf_as_truetype() {
+    let font_bytes = std::fs::read(VAR_TTF).expect("read var.ttf");
+    // var.ttf is a TrueType-flavored sfnt (has a glyf table, no CFF table).
+    assert_eq!(
+        classify_font_program(&font_bytes),
+        Some(FontProgram::TrueType),
+    );
+}
+
+#[test]
+fn composite_font_emits_type0_structure() {
+    // var.ttf lacks most glyphs (the single char below resolves to .notdef),
+    // but the *emission* path is what matters here: a Type0/Identity-H font
+    // with a CIDFontType2 descendant, /W, /ToUnicode, and an embedded
+    // FontFile2 must be produced and parse back cleanly.
+    let font_bytes = std::fs::read(VAR_TTF).expect("read var.ttf");
+    let mut builder = DocumentBuilder::new();
+    let page = builder.add_page(400.0, 200.0);
+    let font = builder
+        .embed_composite_font(font_bytes)
+        .expect("embed composite");
+    builder
+        .add_text_embedded(page, "A", 40.0, 120.0, font, 24.0, (0.0, 0.0, 0.0))
+        .expect("add text");
+    let pdf = builder.build().expect("build");
+
+    let body = String::from_utf8_lossy(&pdf);
+    assert!(body.contains("/Subtype /Type0"), "missing Type0: {body}");
+    assert!(body.contains("/Identity-H"), "missing Identity-H: {body}");
+    assert!(
+        body.contains("/CIDFontType2"),
+        "missing CIDFontType2: {body}"
+    );
+    assert!(
+        body.contains("/CIDToGIDMap /Identity"),
+        "missing CIDToGIDMap"
+    );
+    assert!(body.contains("/ToUnicode"), "missing ToUnicode");
+    assert!(body.contains("/FontFile2"), "missing FontFile2");
+    // The produced PDF parses back through the document pipeline.
+    let doc = PdfDocument::open(pdf.to_vec()).expect("re-open built PDF");
+    assert_eq!(doc.page_count(), 1);
+}
+
+/// The load-bearing CJK round-trip: pull a real embedded Type0 font program
+/// from the committed corpus, re-embed it as a composite font, write a CJK
+/// glyph the font's cmap supports, and confirm it survives the round-trip
+/// (2-byte GID codes + /ToUnicode + subsetting). Skipped when the corpus is
+/// absent or has no extractable Type0 font.
+#[test]
+fn cjk_corpus_font_round_trips() {
+    let Ok(corpus) = std::fs::read(CJK_CORPUS) else {
+        eprintln!("(skipping CJK corpus test: {CJK_CORPUS} not present)");
+        return;
+    };
+    let doc = PdfDocument::open(corpus).expect("open corpus");
+    let Some((font_bytes, program)) = first_embedded_type0_program(&doc) else {
+        eprintln!("(skipping CJK corpus test: no embedded Type0 font found)");
+        return;
+    };
+
+    // Pick a CJK character the font's cmap actually maps, so the 2-byte code
+    // is a real GID (not .notdef) and the ToUnicode round-trips.
+    let face = match ttf_parser::Face::parse(&font_bytes, 0) {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("(skipping CJK corpus test: cannot parse extracted font: {e})");
+            return;
+        }
+    };
+    let Some(cjk_char) = (0x4E00u32..=0x9FFF)
+        .find_map(|cp| char::from_u32(cp).filter(|ch| face.glyph_index(*ch).is_some()))
+    else {
+        eprintln!("(skipping CJK corpus test: font has no CJK BMP glyph");
+        return;
+    };
+
+    let mut builder = DocumentBuilder::new();
+    let page = builder.add_page(400.0, 200.0);
+    let font = builder
+        .embed_composite_font(font_bytes)
+        .expect("embed composite");
+    let s: String = (0..3).map(|_| cjk_char).collect();
+    builder
+        .add_text_embedded(page, &s, 40.0, 120.0, font, 24.0, (0.0, 0.0, 0.0))
+        .expect("add text");
+    let pdf = builder.build().expect("build");
+
+    let body = String::from_utf8_lossy(&pdf);
+    assert!(body.contains("/Subtype /Type0"), "missing Type0");
+    assert!(body.contains("/Identity-H"), "missing Identity-H");
+    let expected_descendant = match program {
+        FontProgram::TrueType => "/CIDFontType2",
+        FontProgram::OpenTypeCff => "/CIDFontType0",
+    };
+    assert!(
+        body.contains(expected_descendant),
+        "missing {expected_descendant}"
+    );
+
+    let text = page0_text(&pdf);
+    assert!(
+        text.contains(&s),
+        "expected {s:?} in extracted CJK text, got: {text:?}"
+    );
+}
+
+/// Walk the corpus object graph for the first `/Subtype /Type0` font and
+/// return its embedded program bytes (FontFile2 or FontFile3) plus the
+/// detected program flavor.
+fn first_embedded_type0_program(doc: &PdfDocument) -> Option<(Vec<u8>, FontProgram)> {
+    let file = doc.file();
+    for id in file.all_object_ids() {
+        let Ok(obj) = file.resolve(id) else { continue };
+        let Ok(dict) = obj.as_dict() else { continue };
+        if dict.get_name("Subtype").ok() != Some("Type0") {
+            continue;
+        }
+        let desc = dict.get("DescendantFonts").and_then(|o| deref(file, o))?;
+        let PdfObject::Array(a) = desc else { continue };
+        let first = deref(file, a.first()?)?;
+        let PdfObject::Dict(cid) = first else {
+            continue;
+        };
+        let fd = cid.get("FontDescriptor").and_then(|o| deref(file, o))?;
+        let PdfObject::Dict(fd) = fd else { continue };
+        // FontFile2 (TrueType) or FontFile3 (OpenType/CFF).
+        if let Ok(ref_id) = fd.get_ref("FontFile2") {
+            if let Ok(data) = file.resolve_stream_data(ref_id) {
+                return Some((data, FontProgram::TrueType));
+            }
+        }
+        if let Ok(ref_id) = fd.get_ref("FontFile3") {
+            if let Ok(data) = file.resolve_stream_data(ref_id) {
+                // The /Subtype on the FontFile3 stream decides CFF vs OpenType,
+                // but for re-embedding both go through the OTF/CFF path here.
+                return Some((data, FontProgram::OpenTypeCff));
+            }
+        }
+    }
+    None
+}
+
+fn deref(file: &zpdf_parser::PdfFile, obj: &PdfObject) -> Option<PdfObject> {
+    match obj {
+        PdfObject::Ref(r) => file.resolve(*r).ok(),
+        other => Some(other.clone()),
+    }
+}

--- a/crates/zpdf-writer/tests/pdfa_convert.rs
+++ b/crates/zpdf-writer/tests/pdfa_convert.rs
@@ -1,0 +1,171 @@
+//! PDF/A conversion end-to-end: convert non-conformant PDFs through
+//! `rewrite_pdf` with `RewriteOptions::pdfa` and confirm the output passes
+//! `zpdf_document::pdfa::validate` for the target profile.
+
+use zpdf_document::pdfa::{validate, Profile};
+use zpdf_parser::PdfFile;
+use zpdf_writer::{DocumentBuilder, PdfaConvertConfig, PdfaProfile, RewriteOptions};
+
+const VAR_TTF: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../crates/zpdf-font/tests/fixtures/var.ttf"
+);
+
+fn conforms(pdf: &[u8], profile: Profile) -> Result<(), String> {
+    let file = PdfFile::parse(pdf.to_vec()).expect("parse");
+    let report = validate(&file, profile);
+    if report.conforms() {
+        Ok(())
+    } else {
+        Err(report
+            .violations
+            .iter()
+            .map(|v| format!("[{}] {}", v.rule, v.message))
+            .collect::<Vec<_>>()
+            .join(", "))
+    }
+}
+
+#[test]
+fn converts_builder_pdf_to_pdfa1b() {
+    let font_bytes = std::fs::read(VAR_TTF).expect("read var.ttf");
+    let mut builder = DocumentBuilder::new();
+    let page = builder.add_page(612.0, 792.0);
+    let font = builder.embed_font(font_bytes).expect("embed");
+    builder
+        .add_text_embedded(page, "Hello", 72.0, 700.0, font, 24.0, (0.0, 0.0, 0.0))
+        .expect("add text");
+    let pdf = builder.build().expect("build");
+
+    // The builder output is not PDF/A-1b (no XMP, no output intent, no /ID,
+    // header 1.7 > 1.4).
+    assert!(
+        conforms(&pdf, Profile::A1b).is_err(),
+        "builder PDF should not yet conform to PDF/A-1b"
+    );
+
+    let file = PdfFile::parse(pdf.to_vec()).expect("parse");
+    let converted = zpdf_writer::rewrite_pdf(
+        &file,
+        &RewriteOptions {
+            pdfa: Some(PdfaConvertConfig {
+                profile: PdfaProfile::A1b,
+                icc: None,
+                fallback_font: None,
+            }),
+            ..Default::default()
+        },
+    )
+    .expect("convert");
+
+    assert!(
+        converted.starts_with(b"%PDF-1.4"),
+        "A-1b conversion must write a 1.4 header"
+    );
+    assert!(
+        conforms(&converted, Profile::A1b).is_ok(),
+        "converted PDF should conform to PDF/A-1b: {}",
+        conforms(&converted, Profile::A1b).unwrap_err()
+    );
+}
+
+#[test]
+fn converts_builder_pdf_to_pdfa2b() {
+    let font_bytes = std::fs::read(VAR_TTF).expect("read var.ttf");
+    let mut builder = DocumentBuilder::new();
+    let page = builder.add_page(612.0, 792.0);
+    let font = builder.embed_font(font_bytes).expect("embed");
+    builder
+        .add_text_embedded(page, "Hello", 72.0, 700.0, font, 24.0, (0.0, 0.0, 0.0))
+        .expect("add text");
+    let pdf = builder.build().expect("build");
+    let file = PdfFile::parse(pdf.to_vec()).expect("parse");
+    let converted = zpdf_writer::rewrite_pdf(
+        &file,
+        &RewriteOptions {
+            pdfa: Some(PdfaConvertConfig {
+                profile: PdfaProfile::A2b,
+                icc: None,
+                fallback_font: None,
+            }),
+            ..Default::default()
+        },
+    )
+    .expect("convert");
+    assert!(
+        converted.starts_with(b"%PDF-1.7"),
+        "A-2b keeps a 1.7 header"
+    );
+    assert!(
+        conforms(&converted, Profile::A2b).is_ok(),
+        "converted PDF should conform to PDF/A-2b: {}",
+        conforms(&converted, Profile::A2b).unwrap_err()
+    );
+}
+
+/// A minimal PDF whose only font is non-embedded (a TrueType with a
+/// FontDescriptor but no FontFile). Converting with a `fallback_font` embeds
+/// it as `/FontFile2`, satisfying PDF/A's embedding requirement.
+#[test]
+fn fallback_font_embeds_nonembedded_font() {
+    let objects: &[&str] = &[
+        "<< /Type /Catalog /Pages 2 0 R >>",
+        "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+         /Resources << /Font << /F1 4 0 R >> >> >>",
+        "<< /Type /Font /Subtype /TrueType /BaseFont /TestFont /FontDescriptor 5 0 R >>",
+        "<< /Type /FontDescriptor /FontName /TestFont /Flags 32 \
+         /FontBBox [0 0 1000 1000] /ItalicAngle 0 /Ascent 800 /Descent -200 \
+         /CapHeight 700 /StemV 80 >>",
+    ];
+    let pdf = build_pdf(objects);
+    // Pre-conversion: fails on fonts, header, XMP, output intent, /ID.
+    assert!(conforms(&pdf, Profile::A1b).is_err());
+
+    let file = PdfFile::parse(pdf.to_vec()).expect("parse");
+    let fallback = std::fs::read(VAR_TTF).expect("read var.ttf");
+    let converted = zpdf_writer::rewrite_pdf(
+        &file,
+        &RewriteOptions {
+            pdfa: Some(PdfaConvertConfig {
+                profile: PdfaProfile::A1b,
+                icc: None,
+                fallback_font: Some(fallback),
+            }),
+            ..Default::default()
+        },
+    )
+    .expect("convert");
+    assert!(
+        conforms(&converted, Profile::A1b).is_ok(),
+        "fallback-embedded PDF should conform to PDF/A-1b: {}",
+        conforms(&converted, Profile::A1b).unwrap_err()
+    );
+}
+
+/// Lay out a PDF from per-object body strings (object N+1 = `objects[N]`),
+/// computing the xref offsets. Mirrors the `build_pdf` test helper used in
+/// zpdf-document.
+fn build_pdf(objects: &[&str]) -> Vec<u8> {
+    let mut data = Vec::new();
+    data.extend_from_slice(b"%PDF-1.7\n");
+    let mut offsets = Vec::new();
+    for (i, body) in objects.iter().enumerate() {
+        offsets.push(data.len());
+        data.extend_from_slice(format!("{} 0 obj\n{}\nendobj\n", i + 1, body).as_bytes());
+    }
+    let xref = data.len();
+    data.extend_from_slice(format!("xref\n0 {}\n", objects.len() + 1).as_bytes());
+    data.extend_from_slice(b"0000000000 65535 f \n");
+    for off in &offsets {
+        data.extend_from_slice(format!("{off:010} 00000 n \n").as_bytes());
+    }
+    data.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF\n",
+            objects.len() + 1
+        )
+        .as_bytes(),
+    );
+    data
+}

--- a/crates/zpdf-writer/tests/sign_production.rs
+++ b/crates/zpdf-writer/tests/sign_production.rs
@@ -1,0 +1,374 @@
+//! Production-grade signing tests: PAdES SubFilter, PEM key loading,
+//! visible signature appearance, embedded extra-certs + /DSS, RFC 3161
+//! timestamp (mock requester), and offline CRL revocation detection.
+
+use zpdf_core::{ObjectId, PdfObject};
+use zpdf_document::{CryptoStatus, PdfDocument, RevocationStatus};
+use zpdf_writer::{
+    AppearanceSpec, IncrementalWriter, SignatureOptions, SigningKey, SubFilter, TimestampRequester,
+};
+
+// ---- helpers copied from tests/sign.rs (minimal DER / X.509 builders) ----
+
+fn minimal_pdf() -> Vec<u8> {
+    let mut data = Vec::new();
+    data.extend_from_slice(b"%PDF-1.4\n");
+    data.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+    data.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+    data.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>\nendobj\n",
+    );
+    data.extend_from_slice(b"xref\n0 4\n");
+    data.extend_from_slice(b"0000000000 65535 f \n");
+    data.extend_from_slice(b"0000000009 00000 n \n");
+    data.extend_from_slice(b"0000000058 00000 n \n");
+    data.extend_from_slice(b"0000000117 00000 n \n");
+    data.extend_from_slice(b"trailer\n<< /Size 4 /Root 1 0 R >>\n");
+    data.extend_from_slice(b"startxref\n187\n%%EOF\n");
+    data
+}
+
+const SEQ: u8 = 0x30;
+const SET: u8 = 0x31;
+const OID: u8 = 0x06;
+const INT: u8 = 0x02;
+const UTF8_STRING: u8 = 0x0c;
+const NULL: u8 = 0x05;
+const BIT_STRING: u8 = 0x03;
+const UTC_TIME: u8 = 0x17;
+
+fn der(tag: u8, content: &[u8]) -> Vec<u8> {
+    let mut out = vec![tag];
+    let len = content.len();
+    if len < 0x80 {
+        out.push(len as u8);
+    } else if len < 0x100 {
+        out.extend_from_slice(&[0x81, len as u8]);
+    } else {
+        out.extend_from_slice(&[0x82, (len >> 8) as u8, (len & 0xff) as u8]);
+    }
+    out.extend_from_slice(content);
+    out
+}
+
+fn bit_string(body: &[u8]) -> Vec<u8> {
+    let mut v = vec![0x00];
+    v.extend_from_slice(body);
+    der(BIT_STRING, &v)
+}
+
+fn build_cert(spki: &[u8], cn: &str) -> Vec<u8> {
+    let cn_oid = [0x55, 0x04, 0x03];
+    let atv = der(
+        SEQ,
+        &[der(OID, &cn_oid), der(UTF8_STRING, cn.as_bytes())].concat(),
+    );
+    let subject = der(SEQ, &der(SET, &atv));
+    let tbs = der(
+        SEQ,
+        &[
+            der(INT, &[0x01]),
+            der(SEQ, &der(OID, &[0x2a])),
+            der(SEQ, &[]),
+            der(SEQ, &[]),
+            subject,
+            spki.to_vec(),
+        ]
+        .concat(),
+    );
+    der(
+        SEQ,
+        &[tbs, der(SEQ, &der(OID, &[0x2a])), bit_string(&[0xde, 0xad])].concat(),
+    )
+}
+
+fn ec_p256_spki(point: &[u8]) -> Vec<u8> {
+    let ec_pub_oid = [0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01];
+    let p256_oid = [0x2a, 0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07];
+    let alg = der(SEQ, &[der(OID, &ec_pub_oid), der(OID, &p256_oid)].concat());
+    der(SEQ, &[alg, bit_string(point)].concat())
+}
+
+fn rsa_spki(pkcs1_pub_der: &[u8]) -> Vec<u8> {
+    let rsa_oid = [0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x01];
+    let alg = der(SEQ, &[der(OID, &rsa_oid), der(NULL, &[])].concat());
+    der(SEQ, &[alg, bit_string(pkcs1_pub_der)].concat())
+}
+
+fn ecdsa_material() -> (Vec<u8>, SigningKey) {
+    let scalar = [0x42u8; 32];
+    let key = SigningKey::ecdsa_p256_from_scalar(&scalar).expect("scalar");
+    let sk = p256::ecdsa::SigningKey::from_slice(&scalar).unwrap();
+    let point = p256::EncodedPoint::from(sk.verifying_key())
+        .to_bytes()
+        .to_vec();
+    (build_cert(&ec_p256_spki(&point), "zpdf signer"), key)
+}
+
+/// A CRL (CertificateList) listing `serial` as revoked. Minimal but enough
+/// for the verifier's `revocation` walker (which scans for the first SEQUENCE
+/// after a Time and reads its children's serial INTEGERs).
+fn crl_revoking(serial: &[u8]) -> Vec<u8> {
+    let revoked_entry = der(
+        SEQ,
+        &[der(INT, serial), der(UTC_TIME, b"230101000000Z")].concat(),
+    );
+    let revoked = der(SEQ, &revoked_entry);
+    let tbs = der(
+        SEQ,
+        &[
+            der(SEQ, &[]),                   // signatureAlgorithm
+            der(SEQ, &[]),                   // issuer
+            der(UTC_TIME, b"230101000000Z"), // thisUpdate
+            revoked,                         // revokedCertificates
+        ]
+        .concat(),
+    );
+    der(
+        SEQ,
+        &[tbs, der(SEQ, &[]), bit_string(&[0xde, 0xad])].concat(),
+    )
+}
+
+fn base64_encode(input: &[u8]) -> String {
+    const TABLE: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::new();
+    let mut bits: u32 = 0;
+    let mut count = 0u32;
+    for &b in input {
+        bits = (bits << 8) | b as u32;
+        count += 8;
+        while count >= 6 {
+            count -= 6;
+            out.push(TABLE[((bits >> count) & 0x3f) as usize] as char);
+        }
+    }
+    if count > 0 {
+        out.push(TABLE[((bits << (6 - count)) & 0x3f) as usize] as char);
+    }
+    while !out.len().is_multiple_of(4) {
+        out.push('=');
+    }
+    out
+}
+
+fn one_sig(signed: &[u8]) -> zpdf_document::Signature {
+    let doc = PdfDocument::open(signed.to_vec()).expect("open");
+    let sigs = doc.signatures();
+    assert_eq!(sigs.len(), 1, "expected exactly one signature");
+    sigs.into_iter().next().unwrap()
+}
+
+#[test]
+fn pades_cades_subfilter_roundtrip() {
+    let (cert, key) = ecdsa_material();
+    let signed = IncrementalWriter::new(minimal_pdf())
+        .expect("writer")
+        .sign(
+            &cert,
+            &key,
+            &SignatureOptions {
+                subfilter: SubFilter::EtsiCAdESDetached,
+                name: Some("Alice".to_string()),
+                ..Default::default()
+            },
+        )
+        .expect("sign");
+    let s = one_sig(&signed);
+    assert_eq!(s.sub_filter.as_deref(), Some("ETSI.CAdES.detached"));
+    assert_eq!(s.crypto, CryptoStatus::Valid, "PAdES CMS verifies");
+}
+
+#[test]
+fn pem_key_loading_signs_and_verifies() {
+    use rand_chacha::rand_core::SeedableRng;
+    use rand_chacha::ChaCha20Rng;
+    use rsa::pkcs1::{EncodeRsaPrivateKey, EncodeRsaPublicKey};
+
+    let mut rng = ChaCha20Rng::from_seed([9u8; 32]);
+    let priv_key = rsa::RsaPrivateKey::new(&mut rng, 2048).expect("keygen");
+    let pub_der = priv_key
+        .to_public_key()
+        .to_pkcs1_der()
+        .expect("pub der")
+        .as_bytes()
+        .to_vec();
+    let cert = build_cert(&rsa_spki(&pub_der), "zpdf RSA signer");
+    let priv_der = priv_key.to_pkcs1_der().expect("priv der");
+    let pem = format!(
+        "-----BEGIN RSA PRIVATE KEY-----\n{}\n-----END RSA PRIVATE KEY-----",
+        base64_encode(priv_der.as_bytes())
+    );
+    let key = SigningKey::rsa_from_pkcs1_pem(pem.as_bytes()).expect("pem key");
+    let signed = IncrementalWriter::new(minimal_pdf())
+        .expect("writer")
+        .sign(&cert, &key, &SignatureOptions::default())
+        .expect("sign");
+    let s = one_sig(&signed);
+    assert_eq!(s.crypto, CryptoStatus::Valid, "PEM-loaded RSA key signs");
+}
+
+#[test]
+fn visible_signature_appearance_emits_nonzero_rect_and_ap() {
+    let (cert, key) = ecdsa_material();
+    let signed = IncrementalWriter::new(minimal_pdf())
+        .expect("writer")
+        .sign(
+            &cert,
+            &key,
+            &SignatureOptions {
+                appearance: Some(AppearanceSpec {
+                    show_text: true,
+                    show_date: true,
+                    ..Default::default()
+                }),
+                name: Some("Alice".to_string()),
+                reason: Some("Approved".to_string()),
+                ..Default::default()
+            },
+        )
+        .expect("sign");
+    // Find the widget annotation on page 0 and confirm it has a non-zero
+    // /Rect and an /AP /N appearance XObject.
+    let doc = PdfDocument::open(signed.to_vec()).expect("open");
+    let file = doc.file();
+    let page = doc.page(0).expect("page");
+    let annots = file
+        .resolve(page.id)
+        .ok()
+        .and_then(|o| o.as_dict().ok().cloned())
+        .expect("page dict");
+    let mut found_widget = false;
+    if let Some(PdfObject::Array(a)) = annots.get("Annots") {
+        for o in a {
+            let PdfObject::Ref(r) = o else { continue };
+            let Ok(PdfObject::Dict(d)) = file.resolve(*r) else {
+                continue;
+            };
+            if d.get_name("Subtype").ok() == Some("Widget") && d.get("AP").is_some() {
+                found_widget = true;
+                if let Some(PdfObject::Array(rect)) = d.get("Rect") {
+                    let nums: Vec<f64> = rect.iter().filter_map(|o| o.as_f64().ok()).collect();
+                    assert_eq!(nums.len(), 4);
+                    assert!(nums[2] > nums[0] && nums[3] > nums[1], "non-zero rect");
+                } else {
+                    panic!("no /Rect");
+                }
+                break;
+            }
+        }
+    }
+    assert!(found_widget, "visible widget with /AP not found");
+}
+
+#[test]
+fn extra_certs_dss_and_crl_revocation_detected() {
+    let (cert, key) = ecdsa_material();
+    // A second (chain) cert and a CRL that revokes the signer's serial (01).
+    let scalar = [0x99u8; 32];
+    let sk2 = p256::ecdsa::SigningKey::from_slice(&scalar).unwrap();
+    let point2 = p256::EncodedPoint::from(sk2.verifying_key())
+        .to_bytes()
+        .to_vec();
+    let extra = build_cert(&ec_p256_spki(&point2), "zpdf intermediate");
+    let crl = crl_revoking(&[0x01]); // signer serial is 01
+
+    let signed = IncrementalWriter::new(minimal_pdf())
+        .expect("writer")
+        .sign(
+            &cert,
+            &key,
+            &SignatureOptions {
+                extra_certs: vec![extra],
+                crls: vec![crl],
+                ..Default::default()
+            },
+        )
+        .expect("sign");
+    let s = one_sig(&signed);
+    assert_eq!(s.crypto, CryptoStatus::Valid);
+    assert!(
+        s.cert_count >= 2,
+        "signer + extra cert embedded: {}",
+        s.cert_count
+    );
+    assert!(s.has_dss, "/DSS written for extra_certs/crls");
+    assert_eq!(
+        s.revocation,
+        RevocationStatus::Revoked,
+        "signer serial 01 is on the embedded CRL"
+    );
+}
+
+#[test]
+fn crl_not_revoked_when_serial_absent() {
+    let (cert, key) = ecdsa_material();
+    // A CRL revoking a *different* serial — the signer (01) is not revoked.
+    let crl = crl_revoking(&[0x77]);
+    let signed = IncrementalWriter::new(minimal_pdf())
+        .expect("writer")
+        .sign(
+            &cert,
+            &key,
+            &SignatureOptions {
+                crls: vec![crl],
+                ..Default::default()
+            },
+        )
+        .expect("sign");
+    let s = one_sig(&signed);
+    assert_eq!(s.revocation, RevocationStatus::NotRevoked);
+}
+
+#[test]
+fn no_crls_means_unknown_revocation() {
+    let (cert, key) = ecdsa_material();
+    let signed = IncrementalWriter::new(minimal_pdf())
+        .expect("writer")
+        .sign(&cert, &key, &SignatureOptions::default())
+        .expect("sign");
+    let s = one_sig(&signed);
+    assert_eq!(s.revocation, RevocationStatus::Unknown);
+}
+
+/// A mock RFC 3161 requester returning a minimal TimeStampResp carrying a
+/// ContentInfo timestamp token. The token's content is irrelevant to the
+/// verifier's `has_timestamp` (which scans the signer CMS for the timestamp
+/// attribute OID); it only needs to be a parseable token.
+struct MockTsa;
+impl TimestampRequester for MockTsa {
+    fn request_timestamp(&self, _tsq: &[u8]) -> zpdf_core::Result<Vec<u8>> {
+        // TimeStampResp ::= SEQUENCE { status PKIStatusInfo, timeStampToken? }
+        let status = der(SEQ, &[]);
+        let token = der(SEQ, &[der(OID, &[0x2a])].concat()); // a minimal ContentInfo
+        Ok(der(SEQ, &[status, token].concat()))
+    }
+}
+
+#[test]
+fn rfc3161_timestamp_embedded_via_requester() {
+    let (cert, key) = ecdsa_material();
+    let signed = IncrementalWriter::new(minimal_pdf())
+        .expect("writer")
+        .sign(
+            &cert,
+            &key,
+            &SignatureOptions {
+                timestamp: Some(Box::new(MockTsa)),
+                ..Default::default()
+            },
+        )
+        .expect("sign");
+    let s = one_sig(&signed);
+    assert_eq!(s.crypto, CryptoStatus::Valid);
+    assert!(
+        s.has_timestamp,
+        "CMS should carry a signature-time-stamp unsigned attribute"
+    );
+}
+
+// Keep the ObjectId import used by the visible-appearance walk compiled.
+#[allow(dead_code)]
+fn _use_objectid() -> ObjectId {
+    ObjectId(0, 0)
+}

--- a/crates/zpdf-writer/tests/tagged.rs
+++ b/crates/zpdf-writer/tests/tagged.rs
@@ -1,0 +1,216 @@
+//! Tagged-PDF authoring round-trip: build a document with tagged text/image
+//! items, then read it back through `PdfDocument::struct_tree()` and confirm
+//! the structure tree, roles, MCIDs, and `/Alt` survive — and that the document
+//! declares itself tagged (`/MarkInfo /Marked true`).
+
+use zpdf_document::{PdfDocument, StructKid, StructRole};
+use zpdf_writer::{DocumentBuilder, ImageData, TagSpec};
+
+#[test]
+fn tagged_pdf_round_trips_through_structure_tree() {
+    let mut builder = DocumentBuilder::new();
+    builder.set_lang("en");
+    let page = builder.add_page(612.0, 792.0);
+    builder
+        .add_tagged_text(
+            page,
+            "Title",
+            72.0,
+            700.0,
+            "Helvetica",
+            24.0,
+            (0.0, 0.0, 0.0),
+            TagSpec {
+                role: StructRole::H1,
+                alt: None,
+                actual_text: None,
+            },
+        )
+        .unwrap();
+    builder
+        .add_tagged_text(
+            page,
+            "Body paragraph.",
+            72.0,
+            660.0,
+            "Helvetica",
+            12.0,
+            (0.0, 0.0, 0.0),
+            TagSpec {
+                role: StructRole::P,
+                alt: None,
+                actual_text: None,
+            },
+        )
+        .unwrap();
+    builder
+        .add_tagged_image(
+            page,
+            ImageData::Rgb8 {
+                width: 1,
+                height: 1,
+                pixels: vec![0, 0, 0],
+            },
+            72.0,
+            600.0,
+            40.0,
+            40.0,
+            TagSpec {
+                role: StructRole::Figure,
+                alt: Some("A chart".to_string()),
+                actual_text: None,
+            },
+        )
+        .unwrap();
+
+    let pdf = builder.build().expect("build");
+    let body = String::from_utf8_lossy(&pdf);
+    assert!(body.contains("/StructTreeRoot"), "missing StructTreeRoot");
+    assert!(
+        body.contains("/Marked true"),
+        "missing /MarkInfo /Marked true"
+    );
+    assert!(body.contains("/StructParents"), "missing /StructParents");
+    assert!(body.contains("/Lang"), "missing /Lang");
+
+    let doc = PdfDocument::open(pdf.to_vec()).expect("open");
+    assert!(doc.is_tagged(), "document should declare itself tagged");
+    let tree = doc.struct_tree().expect("struct tree").clone();
+    assert!(
+        tree.marked,
+        "/MarkInfo /Marked true should surface as marked"
+    );
+
+    // Three top-level elements, in the order they were tagged, each carrying
+    // its MCID kid.
+    assert_eq!(tree.children.len(), 3, "expected 3 top-level elements");
+    let h1 = &tree.children[0];
+    assert_eq!(h1.role, StructRole::H1);
+    assert_eq!(h1.page, Some(0));
+    assert_eq!(
+        h1.kids,
+        vec![StructKid::MarkedContent {
+            page: Some(0),
+            mcid: 0
+        }]
+    );
+    let p = &tree.children[1];
+    assert_eq!(p.role, StructRole::P);
+    assert_eq!(
+        p.kids,
+        vec![StructKid::MarkedContent {
+            page: Some(0),
+            mcid: 1
+        }]
+    );
+    let fig = &tree.children[2];
+    assert_eq!(fig.role, StructRole::Figure);
+    assert_eq!(fig.alt.as_deref(), Some("A chart"));
+    assert_eq!(
+        fig.kids,
+        vec![StructKid::MarkedContent {
+            page: Some(0),
+            mcid: 2
+        }]
+    );
+}
+
+#[test]
+fn untagged_pdf_has_no_struct_tree() {
+    let mut builder = DocumentBuilder::new();
+    let page = builder.add_page(200.0, 200.0);
+    builder
+        .add_text(
+            page,
+            "plain",
+            10.0,
+            10.0,
+            "Helvetica",
+            12.0,
+            (0.0, 0.0, 0.0),
+        )
+        .unwrap();
+    let pdf = builder.build().expect("build");
+    let body = String::from_utf8_lossy(&pdf);
+    assert!(
+        !body.contains("/StructTreeRoot"),
+        "untagged PDF must not emit a tree"
+    );
+    let doc = PdfDocument::open(pdf.to_vec()).expect("open");
+    assert!(!doc.is_tagged());
+    assert!(doc.struct_tree().is_none());
+}
+
+#[test]
+fn tagged_document_passes_pdfua_validator() {
+    // A realistically-tagged document: a heading, a paragraph, and a figure
+    // with alt text, a declared language, and every page tagged. This must
+    // conform to the PDF/UA-1 validator the writer's output is designed for.
+    let mut builder = DocumentBuilder::new();
+    builder.set_lang("en-US");
+    let page = builder.add_page(612.0, 792.0);
+    builder
+        .add_tagged_text(
+            page,
+            "Heading",
+            72.0,
+            700.0,
+            "Helvetica",
+            24.0,
+            (0.0, 0.0, 0.0),
+            TagSpec {
+                role: StructRole::H1,
+                alt: None,
+                actual_text: None,
+            },
+        )
+        .unwrap();
+    builder
+        .add_tagged_text(
+            page,
+            "A paragraph of body text.",
+            72.0,
+            660.0,
+            "Helvetica",
+            12.0,
+            (0.0, 0.0, 0.0),
+            TagSpec {
+                role: StructRole::P,
+                alt: None,
+                actual_text: None,
+            },
+        )
+        .unwrap();
+    builder
+        .add_tagged_image(
+            page,
+            ImageData::Rgb8 {
+                width: 2,
+                height: 2,
+                pixels: vec![0, 0, 0, 255, 255, 255, 255, 255, 255, 0, 0, 0],
+            },
+            72.0,
+            600.0,
+            40.0,
+            40.0,
+            TagSpec {
+                role: StructRole::Figure,
+                alt: Some("A two-by-two checkerboard".to_string()),
+                actual_text: None,
+            },
+        )
+        .unwrap();
+
+    let pdf = builder.build().expect("build");
+    let doc = PdfDocument::open(pdf.to_vec()).expect("open");
+    let report = zpdf_document::pdfua::validate(doc.file(), zpdf_document::pdfua::Profile::Ua1);
+    assert!(
+        report.conforms(),
+        "expected PDF/UA-1 conformance, got: {:?}",
+        report
+            .violations
+            .iter()
+            .map(|v| format!("[{}] {}", v.rule, v.message))
+            .collect::<Vec<_>>()
+    );
+}

--- a/crates/zpdf/src/lib.rs
+++ b/crates/zpdf/src/lib.rs
@@ -20,8 +20,8 @@ pub use zpdf_document::{
     AcroForm, Annotation, ByteRangeCoverage, CryptoStatus, DestView, Destination, DigestStatus,
     DocInfo, EmbeddedFile, EmbeddedSource, FieldKind, FieldValue, FormField,
     GeographicCoordinateSystem, Measure, OcConfig, OutlineItem, OutputIntent, PageLabelStyle,
-    PageLabels, PdfDocument, PdfPage, ResourceDict, Signature, StructElem, StructKid, StructRole,
-    StructTree, XmpMetadata,
+    PageLabels, PdfDocument, PdfPage, ResourceDict, RevocationStatus, Signature, StructElem,
+    StructKid, StructRole, StructTree, XmpMetadata,
 };
 pub use zpdf_font::FontCache;
 pub use zpdf_image::{DecodedImage, ImageCache};

--- a/crates/zpdf/src/lib.rs
+++ b/crates/zpdf/src/lib.rs
@@ -14,6 +14,7 @@ pub use zpdf_core::*;
 pub use zpdf_display_list as display_list;
 pub use zpdf_display_list::DisplayList;
 pub use zpdf_document::pdfa;
+pub use zpdf_document::pdfua;
 pub use zpdf_document::trust;
 pub use zpdf_document::{
     AcroForm, Annotation, ByteRangeCoverage, CryptoStatus, DestView, Destination, DigestStatus,


### PR DESCRIPTION
Closes the four "real feature gaps in existing subsystems" with full implementations, one commit per feature. Pure Rust, zero new C/C++ deps (only optional `ureq` behind the `zpdf-writer` \`timestamp\` feature). `cargo test --workspace` green (1087 tests), `cargo clippy --workspace --all-targets -D warnings` clean; default / `gpu` / `timestamp` feature builds all pass.

## #4 — CJK-capable authoring (Type0/Identity-H)
`DocumentBuilder::embed_composite_font` embeds a font as a Type0/Identity-H composite font (CJK-capable): TrueType-flavored (`CIDFontType2`/`FontFile2`) and CFF-flavored (`CIDFontType0`/`FontFile3 /OpenType`), raw CFF auto-wrapped in OTF. New `cff.rs` (sparse-charstring CFF subsetting, ported CFF walkers) + `tounicode.rs` (`/ToUnicode` CMap serializer). 2-byte GID hex text, sparse `/W`, `/CIDToGIDMap /Identity`. Round-trip verified on a real CJK font from `tests/test1/1.pdf`.

## #7 — Tagged-PDF authoring + PDF/UA-1 validator
`DocumentBuilder::add_tagged_text[_embedded]`/`add_tagged_image`/`add_tagged_path` + `TagSpec` wrap items in `/Role <</MCID N>> BDC … EMC` and emit `/StructTreeRoot` + `/ParentTree` + `/MarkInfo` + `/Lang` + page `/StructParents`. New `pdfua.rs` validator (tagged/struct-tree/lang/figure-alt/headings/role-unmapped/page-struct-parents). CLI `validate --profile pdfua-1`. Builder-tagged document passes the validator.

## #6 — PDF/A conversion
`rewrite_pdf` gains `RewriteOptions::pdfa` (`PdfaConvertConfig`): injects `GTS_PDFA1` output intent + sRGB ICC, writes `pdfaid` XMP, strips forbidden features (JS/launch/embedded-files/transparency for A-1b), fixes header (1.4 for A-1b), backfills `/ID`, embeds a caller-supplied fallback font for non-embedded simple fonts. New `pdfa_convert.rs`. CLI `optimize --pdfa pdfa-1b|pdfa-2b --fallback-font --icc`. Convert→validate round-trip verified on builder PDFs and `tests/test6/1.pdf`.

## #5 — Production-grade signing
Sign side: `SubFilter` (PAdES `ETSI.CAdES.detached`), `AppearanceSpec` (visible `/AP /N` + `/MK` + `/DA`), PEM key/cert loading (hand-rolled base64), multi-cert CMS + CRLs, RFC 3161 timestamp (pluggable `TimestampRequester` + `UreqTimestampRequester` behind `timestamp` feature, two-phase), `/DSS` for LTV. Verify side: `Signature` gains `has_timestamp`/`cert_count`/`has_dss`/`revocation` (`RevocationStatus` via offline embedded-CRL scan). CLI `sign --subfilter --appearance --tsa --cert-chain --crl`; `signatures` prints the new fields. Round-trip verified incl. PAdES, PEM, appearance, CRL Revoked/NotRevoked/Unknown, mock-requester timestamp; existing detached-PKCS#7 round-trips unchanged.

## Deferred (documented in code)
#4: legacy predefined 2-byte CMap (UniGB/UniJIS) authoring, Identity-V. #6: Type0/CID non-embedded font fallback. #5: PFX/PKCS#12, OCSP/CRL network fetch, TSA-signature verification. #7: re-tagging existing PDFs, PDF/UA-2, annotation OBJR coverage.